### PR TITLE
Add rate-limited request queue for player/season lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,17 @@ source .venv/bin/activate
 2. Install dependencies:
 
 ```bash
-pip install -r requirements.txt  # requests, python-dotenv, aiohttp
+pip install -r requirements.txt  # python-dotenv, aiohttp
 ```
 
 3. Set up a `.env` file with your PUBG API key:
 
 ```
 PUBG_API_KEY=your_api_key_here
+
+# Optional: default rate limit (requests/minute) for /players and /seasons
+# calls, used until the API's response headers take over. Defaults to 10.
+PUBG_RATE_LIMIT_PER_MINUTE=10
 ```
 
 4. Run it against a player name:
@@ -62,7 +66,7 @@ main.py
 
 ```
 ├── main.py                 # CLI entry point
-├── api/                     # PUBG API client: player stats, telemetry, player index
+├── api/                     # PUBG API client: player stats, telemetry, player index, rate limiter
 ├── utils/                   # Display formatting + I/O helpers
 ├── tests/                   # Unit tests
 ├── docs/                    # Vision, design specs, sample output
@@ -78,6 +82,11 @@ main.py
 - Only telemetry files are required to analyze bot/player behavior.
 - Match IDs come from cached stats, not fresh API calls, to avoid rate
   limits - match JSON doesn't change once a match is generated.
+- `/players` and `/seasons` calls are serialized through a request queue
+  (`api/rate_limiter.py`) that throttles to the API's live
+  `X-RateLimit-*` headers, falling back to `PUBG_RATE_LIMIT_PER_MINUTE`
+  until headers are seen. `/matches` and telemetry URLs are not
+  rate-limited and bypass the queue.
 
 ## Sample Output
 

--- a/api/player_stats.py
+++ b/api/player_stats.py
@@ -2,9 +2,9 @@
 # api/player_stats.py
 # ==============================
 import os
-import requests
 from dotenv import load_dotenv
 from api.player_index import update_player_index
+from api.rate_limiter import player_api_queue
 
 load_dotenv()
 
@@ -16,12 +16,10 @@ HEADERS = {
 BASE_URL = "https://api.pubg.com/shards/steam"
 
 
-def fetch_player_stats(playername):
+async def fetch_player_stats(playername):
     # Get account ID from player name
     player_url = f"{BASE_URL}/players?filter[playerNames]={playername}"
-    resp = requests.get(player_url, headers=HEADERS)
-    resp.raise_for_status()
-    player_data = resp.json()
+    player_data = await player_api_queue.request("GET", player_url, headers=HEADERS)
     player_id = player_data["data"][0]["id"]
 
     # Update the player index (no match_ids yet)
@@ -29,6 +27,5 @@ def fetch_player_stats(playername):
 
     # Get lifetime stats
     stats_url = f"{BASE_URL}/players/{player_id}/seasons/lifetime"
-    resp = requests.get(stats_url, headers=HEADERS)
-    resp.raise_for_status()
-    return resp.json(), player_id
+    stats_data = await player_api_queue.request("GET", stats_url, headers=HEADERS)
+    return stats_data, player_id

--- a/api/rate_limiter.py
+++ b/api/rate_limiter.py
@@ -1,0 +1,95 @@
+# ==============================
+# api/rate_limiter.py
+# ==============================
+import os
+import time
+import asyncio
+import logging
+
+import aiohttp
+
+logger = logging.getLogger("rate_limiter")
+if not logger.handlers:
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("[%(levelname)s] %(message)s"))
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+DEFAULT_LIMIT_PER_MINUTE = int(os.getenv("PUBG_RATE_LIMIT_PER_MINUTE", 10))
+
+
+class RateLimitedQueue:
+    """Serializes requests to rate-limited PUBG API endpoints.
+
+    Falls back to a configurable default rate (requests/minute) until the
+    API's X-RateLimit-* response headers are seen, then throttles against
+    the reported Limit/Remaining/Reset instead.
+    """
+
+    def __init__(self, default_limit_per_minute=DEFAULT_LIMIT_PER_MINUTE):
+        self._lock = asyncio.Lock()
+        self._session = None
+        self._limit = default_limit_per_minute
+        self._remaining = None
+        self._reset_at = None
+        self._last_request_at = None
+
+    async def _get_session(self):
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession()
+        return self._session
+
+    async def close(self):
+        if self._session and not self._session.closed:
+            await self._session.close()
+
+    async def _wait_for_slot(self):
+        if self._remaining is not None and self._remaining <= 0 and self._reset_at:
+            wait_time = self._reset_at - time.time()
+            if wait_time > 0:
+                logger.info(f"Rate limit exhausted, pausing queue for {wait_time:.1f}s until reset")
+                await asyncio.sleep(wait_time)
+            return
+
+        if self._last_request_at is not None:
+            min_interval = 60.0 / self._limit
+            elapsed = time.time() - self._last_request_at
+            if elapsed < min_interval:
+                wait_time = min_interval - elapsed
+                logger.info(f"Throttling to {self._limit}/min, waiting {wait_time:.1f}s")
+                await asyncio.sleep(wait_time)
+
+    def _update_from_headers(self, headers):
+        limit = headers.get("X-RateLimit-Limit")
+        remaining = headers.get("X-RateLimit-Remaining")
+        reset = headers.get("X-RateLimit-Reset")
+
+        if limit is not None:
+            self._limit = int(limit)
+        if remaining is not None:
+            self._remaining = int(remaining)
+        if reset is not None:
+            self._reset_at = float(reset)
+
+    async def request(self, method, url, headers=None, **kwargs):
+        async with self._lock:
+            logger.info(f"Queued {method} {url}")
+            await self._wait_for_slot()
+
+            session = await self._get_session()
+            async with session.request(method, url, headers=headers, **kwargs) as response:
+                self._update_from_headers(response.headers)
+                self._last_request_at = time.time()
+                response.raise_for_status()
+                data = await response.json()
+
+            logger.info(
+                f"Released {method} {url} "
+                f"(remaining={self._remaining}, limit={self._limit})"
+            )
+            return data
+
+
+# Shared queue for all rate-limited endpoints (/players, /seasons).
+# /matches and telemetry URLs are not rate-limited and must bypass this queue.
+player_api_queue = RateLimitedQueue()

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@
 # main CLI entry point
 # ==============================
 from api.player_stats import fetch_player_stats
+from api.rate_limiter import player_api_queue
 from utils.io_helpers import save_json
 from utils.display_stats_by_mode import render_ascii_table, load_player_stats
 from utils.display_match_history import display_match_history
@@ -11,38 +12,46 @@ import asyncio
 
 import argparse
 
+async def run(playername):
+    try:
+        await _run(playername)
+    finally:
+        await player_api_queue.close()
+
+async def _run(playername):
+    data, player_id = await fetch_player_stats(playername)
+    save_json(data, f"playerstats/{playername}.json")
+    print(f"[SUCCESS] Stats saved for '{playername}' (account ID: {player_id})")
+    print()
+    print()
+
+    # Display stats as ASCII table
+    stats = load_player_stats(f"playerstats/{playername}.json")
+    render_ascii_table(stats, playername)
+
+    # Display match history grouped by mode
+    print("\n\n")
+    display_match_history(playername)
+
+    # Fetch telemetry for all matches
+    match_ids = []
+    relationships = data["data"]["relationships"]
+    for key in relationships:
+        if key.startswith("matches"):
+            match_ids.extend([entry["id"] for entry in relationships[key].get("data", [])])
+
+    print()
+    print()
+    #print(f"[INFO] Fetching telemetry for {len(match_ids)} matches...")
+    #await fetch_telemetry_for_matches(match_ids) # Temporarily Disabled until Rate Limiting Deployed - IP Ban Risk!!! crap.
+
 def main():
     parser = argparse.ArgumentParser(description="Query and save PUBG lifetime player stats.")
     parser.add_argument("playername", help="The PUBG player name to query")
     args = parser.parse_args()
 
     try:
-        data, player_id = fetch_player_stats(args.playername)
-        save_json(data, f"playerstats/{args.playername}.json")
-        print(f"[SUCCESS] Stats saved for '{args.playername}' (account ID: {player_id})")
-        print()
-        print()
-        
-        # Display stats as ASCII table
-        stats = load_player_stats(f"playerstats/{args.playername}.json")
-        render_ascii_table(stats, args.playername)
-
-        # Display match history grouped by mode
-        print("\n\n")
-        display_match_history(args.playername)
-
-        # Fetch telemetry for all matches
-        match_ids = []
-        relationships = data["data"]["relationships"]
-        for key in relationships:
-            if key.startswith("matches"):
-                match_ids.extend([entry["id"] for entry in relationships[key].get("data", [])])
-
-        print()
-        print()
-        #print(f"[INFO] Fetching telemetry for {len(match_ids)} matches...")
-        #asyncio.run(fetch_telemetry_for_matches(match_ids)) # Temporarily Disabled until Rate Limiting Deployed - IP Ban Risk!!! crap.
-        
+        asyncio.run(run(args.playername))
     except Exception as e:
         print(f"[ERROR] {e}")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-requests
 python-dotenv
 aiohttp

--- a/tests/test_player_stats.py
+++ b/tests/test_player_stats.py
@@ -1,34 +1,34 @@
 ##########
-# Unit Test for Player Stats API 
+# Unit Test for Player Stats API
 # fromn root of project: `python -m unittest discover tests`
 ##########
 
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, AsyncMock
 from api.player_stats import fetch_player_stats
 
 MOCK_PLAYER_ID = "account.mocked123"
 MOCK_STATS = {"mock": "stats_json_data"}
 
-class TestPlayerStatsQuery(unittest.TestCase):
-    
-    @patch("api.player_stats.requests.get")
-    def test_fetch_player_stats(self, mock_get):
-        # --- Mock /players endpoint ---
-        mock_get.side_effect = [
+class TestPlayerStatsQuery(unittest.IsolatedAsyncioTestCase):
+
+    @patch("api.player_stats.update_player_index")
+    @patch("api.player_stats.player_api_queue.request", new_callable=AsyncMock)
+    async def test_fetch_player_stats(self, mock_request, mock_update_index):
+        # --- Mock the rate-limited queue's responses ---
+        mock_request.side_effect = [
             # First call: get player ID
-            unittest.mock.Mock(status_code=200, json=lambda: {
-                "data": [{"id": MOCK_PLAYER_ID}]
-            }),
+            {"data": [{"id": MOCK_PLAYER_ID}]},
             # Second call: get player stats
-            unittest.mock.Mock(status_code=200, json=lambda: MOCK_STATS)
+            MOCK_STATS
         ]
 
-        stats, player_id = fetch_player_stats("FakePlayer")
-        
+        stats, player_id = await fetch_player_stats("FakePlayer")
+
         self.assertEqual(player_id, MOCK_PLAYER_ID)
         self.assertEqual(stats, MOCK_STATS)
-        self.assertEqual(mock_get.call_count, 2)
+        self.assertEqual(mock_request.call_count, 2)
+        mock_update_index.assert_called_once_with(account_id=MOCK_PLAYER_ID, playername="FakePlayer")
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,0 +1,84 @@
+##########
+# Unit Test for Request Queue / Rate Limiter
+# from root of project: `python -m unittest discover tests`
+##########
+
+import time
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from api.rate_limiter import RateLimitedQueue
+
+
+def make_mock_session(headers, json_data):
+    response = MagicMock()
+    response.headers = headers
+    response.raise_for_status = MagicMock()
+    response.json = AsyncMock(return_value=json_data)
+
+    response_cm = MagicMock()
+    response_cm.__aenter__ = AsyncMock(return_value=response)
+    response_cm.__aexit__ = AsyncMock(return_value=False)
+
+    session = MagicMock()
+    session.closed = False
+    session.request = MagicMock(return_value=response_cm)
+    return session
+
+
+class TestRateLimitedQueue(unittest.IsolatedAsyncioTestCase):
+
+    async def test_updates_state_from_response_headers(self):
+        queue = RateLimitedQueue(default_limit_per_minute=10)
+        session = make_mock_session(
+            headers={"X-RateLimit-Limit": "10", "X-RateLimit-Remaining": "9", "X-RateLimit-Reset": "1700000000"},
+            json_data={"ok": True},
+        )
+        queue._session = session
+
+        result = await queue.request("GET", "https://api.pubg.com/shards/steam/players")
+
+        self.assertEqual(result, {"ok": True})
+        self.assertEqual(queue._limit, 10)
+        self.assertEqual(queue._remaining, 9)
+        self.assertEqual(queue._reset_at, 1700000000.0)
+
+    async def test_pauses_when_remaining_is_zero(self):
+        queue = RateLimitedQueue(default_limit_per_minute=10)
+        queue._remaining = 0
+        queue._reset_at = time.time() + 5
+
+        with patch("api.rate_limiter.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            await queue._wait_for_slot()
+
+        mock_sleep.assert_awaited_once()
+        waited = mock_sleep.call_args.args[0]
+        self.assertGreater(waited, 0)
+        self.assertLessEqual(waited, 5)
+
+    async def test_throttles_to_default_interval_without_headers(self):
+        queue = RateLimitedQueue(default_limit_per_minute=60)  # 1 req/sec
+        queue._last_request_at = time.time()
+
+        with patch("api.rate_limiter.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            await queue._wait_for_slot()
+
+        mock_sleep.assert_awaited_once()
+        waited = mock_sleep.call_args.args[0]
+        self.assertGreater(waited, 0)
+        self.assertLessEqual(waited, 1)
+
+    async def test_no_wait_when_remaining_available(self):
+        queue = RateLimitedQueue(default_limit_per_minute=10)
+        queue._remaining = 5
+        queue._reset_at = time.time() + 60
+        queue._last_request_at = time.time() - 60
+
+        with patch("api.rate_limiter.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            await queue._wait_for_slot()
+
+        mock_sleep.assert_not_awaited()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Serializes /players and /seasons calls through an async request queue instead of firing them immediately
- Throttles to a configurable default rate (PUBG_RATE_LIMIT_PER_MINUTE, default 10/min) until live X-RateLimit-* response headers take over
- Pauses the queue when the rate limit is exhausted and resumes safely after the reset window
- /matches and telemetry URLs continue to bypass the queue, unaffected

## Test plan
- [x] Unit tests: `python -m unittest discover tests` (5 passing, mocked)
- [x] Live smoke test against the real API (single known player, 2 requests): confirmed the queue throttled the second call for 6.0s per the default rate, then picked up live headers (remaining=8, limit=10) with no 429s

Closes #12