### PR TITLE
Add combat stats summary with elimination/death breakdown

### DIFF
--- a/api/telemetry_fetcher.py
+++ b/api/telemetry_fetcher.py
@@ -66,12 +66,29 @@ async def fetch_and_save_telemetry(session, match_id, semaphore):
         return ("failed", match_id)
 
 
-async def fetch_telemetry_for_matches(match_ids, concurrency=None):
+def _is_cached(match_id):
+    return os.path.exists(os.path.join(TELEMETRY_DIR, f"{match_id}-telemetry.json"))
+
+
+async def fetch_telemetry_for_matches(match_ids, concurrency=None, max_new_per_run=None):
     if concurrency is None:
-        concurrency = int(os.getenv("TELEMETRY_CONCURRENCY", 5))
+        concurrency = int(os.getenv("TELEMETRY_CONCURRENCY", 3))
+    if max_new_per_run is None:
+        max_new_per_run = int(os.getenv("TELEMETRY_MAX_NEW_PER_RUN", 25))
+
+    cached = [m for m in match_ids if _is_cached(m)]
+    new_matches = [m for m in match_ids if m not in cached]
+
+    if len(new_matches) > max_new_per_run:
+        print(
+            f"[INFO] {len(new_matches)} new matches found; fetching {max_new_per_run} this run "
+            f"to stay conservative on telemetry requests. Re-run later to continue backfilling."
+        )
+    to_fetch = cached + new_matches[:max_new_per_run]
+
     semaphore = asyncio.Semaphore(concurrency)
     async with aiohttp.ClientSession() as session:
-        tasks = [fetch_and_save_telemetry(session, match_id, semaphore) for match_id in match_ids]
+        tasks = [fetch_and_save_telemetry(session, match_id, semaphore) for match_id in to_fetch]
         results = await asyncio.gather(*tasks)
 
     saved = [m for status, m in results if status == "saved"]

--- a/main.py
+++ b/main.py
@@ -7,6 +7,8 @@ from utils.io_helpers import save_json
 from utils.display_stats_by_mode import render_ascii_table, load_player_stats
 from utils.display_match_history import display_match_history
 from api.telemetry_fetcher import fetch_telemetry_for_matches
+from utils.combat_stats import compute_combat_stats
+from utils.display_combat_stats import render_combat_stats
 import asyncio
 
 
@@ -42,8 +44,13 @@ async def _run(playername):
 
     print()
     print()
-    #print(f"[INFO] Fetching telemetry for {len(match_ids)} matches...")
-    #await fetch_telemetry_for_matches(match_ids) # Temporarily Disabled until Rate Limiting Deployed - IP Ban Risk!!! crap.
+    print(f"[INFO] Fetching telemetry for {len(match_ids)} matches...")
+    await fetch_telemetry_for_matches(match_ids)
+
+    # Display combat stats mined from cached telemetry
+    print("\n\n")
+    combat_stats = compute_combat_stats(player_id)
+    render_combat_stats(combat_stats)
 
 def main():
     parser = argparse.ArgumentParser(description="Query and save PUBG lifetime player stats.")

--- a/tests/test_combat_stats.py
+++ b/tests/test_combat_stats.py
@@ -1,0 +1,70 @@
+##########
+# Unit Test for Combat Stats parsing
+# from root of project: `python -m unittest discover tests`
+##########
+
+import unittest
+from utils.combat_stats import compute_combat_stats_from_events
+
+ME = "account.me"
+RIVAL_A = "account.rival_a"
+RIVAL_B = "account.rival_b"
+
+
+def kill_event(killer_id, killer_name, victim_id, victim_name, is_suicide=False,
+               killer_type="user", victim_type="user"):
+    return {
+        "_T": "LogPlayerKillV2",
+        "isSuicide": is_suicide,
+        "killer": {"accountId": killer_id, "name": killer_name, "type": killer_type},
+        "victim": {"accountId": victim_id, "name": victim_name, "type": victim_type},
+    }
+
+
+class TestCombatStats(unittest.TestCase):
+
+    def test_tallies_eliminations_and_deaths_by_opponent(self):
+        documents = [[
+            kill_event(ME, "Me", RIVAL_A, "RivalA"),
+            kill_event(ME, "Me", RIVAL_A, "RivalA"),
+            kill_event(RIVAL_B, "RivalB", ME, "Me"),
+        ]]
+
+        stats = compute_combat_stats_from_events(ME, documents)
+
+        self.assertEqual(stats["total_eliminations"], 2)
+        self.assertEqual(stats["total_deaths"], 1)
+        self.assertEqual(stats["eliminations_breakdown"], {"RivalA": 2})
+        self.assertEqual(stats["deaths_breakdown"], {"RivalB": 1})
+
+    def test_excludes_suicides(self):
+        documents = [[kill_event(ME, "Me", ME, "Me", is_suicide=True)]]
+
+        stats = compute_combat_stats_from_events(ME, documents)
+
+        self.assertEqual(stats["total_eliminations"], 0)
+        self.assertEqual(stats["total_deaths"], 0)
+
+    def test_excludes_non_user_killers_and_victims(self):
+        # Environmental deaths (bluezone, falls) have no real opposing player.
+        documents = [[kill_event(ME, "Me", "npc.bluezone", "BlueZone", killer_type="npc")]]
+
+        stats = compute_combat_stats_from_events(ME, documents)
+
+        self.assertEqual(stats["total_deaths"], 0)
+        self.assertEqual(stats["deaths_breakdown"], {})
+
+    def test_breakdown_sorted_descending(self):
+        documents = [[
+            kill_event(ME, "Me", RIVAL_A, "RivalA"),
+            kill_event(ME, "Me", RIVAL_B, "RivalB"),
+            kill_event(ME, "Me", RIVAL_B, "RivalB"),
+        ]]
+
+        stats = compute_combat_stats_from_events(ME, documents)
+
+        self.assertEqual(list(stats["eliminations_breakdown"].items()), [("RivalB", 2), ("RivalA", 1)])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/utils/combat_stats.py
+++ b/utils/combat_stats.py
@@ -1,0 +1,61 @@
+# ==============================
+# utils/combat_stats.py
+# ==============================
+import glob
+import json
+import os
+
+TELEMETRY_DIR = "match-telemetry"
+
+
+def _load_telemetry_files(match_ids=None, telemetry_dir=TELEMETRY_DIR):
+    for path in glob.glob(os.path.join(telemetry_dir, "*-telemetry.json")):
+        match_id = os.path.basename(path).replace("-telemetry.json", "")
+        if match_ids is not None and match_id not in match_ids:
+            continue
+        with open(path, "r") as f:
+            yield json.load(f)
+
+
+def compute_combat_stats_from_events(account_id, telemetry_documents):
+    """Tally eliminations/deaths against real opponents from parsed telemetry.
+
+    Environmental deaths (bluezone, falls, drowning) and suicides have no
+    opposing player and are excluded, since the breakdown is keyed by
+    opponent name.
+    """
+    eliminations = {}
+    deaths = {}
+
+    for telemetry in telemetry_documents:
+        for event in telemetry:
+            if event.get("_T") != "LogPlayerKillV2" or event.get("isSuicide"):
+                continue
+
+            killer = event.get("killer") or {}
+            victim = event.get("victim") or {}
+
+            if killer.get("type") != "user" or victim.get("type") != "user":
+                continue
+
+            if killer.get("accountId") == account_id and victim.get("accountId") != account_id:
+                name = victim.get("name", "Unknown")
+                eliminations[name] = eliminations.get(name, 0) + 1
+
+            if victim.get("accountId") == account_id and killer.get("accountId") != account_id:
+                name = killer.get("name", "Unknown")
+                deaths[name] = deaths.get(name, 0) + 1
+
+    return {
+        "total_eliminations": sum(eliminations.values()),
+        "total_deaths": sum(deaths.values()),
+        "eliminations_breakdown": dict(sorted(eliminations.items(), key=lambda kv: kv[1], reverse=True)),
+        "deaths_breakdown": dict(sorted(deaths.items(), key=lambda kv: kv[1], reverse=True)),
+    }
+
+
+def compute_combat_stats(account_id, match_ids=None, telemetry_dir=TELEMETRY_DIR):
+    documents = list(_load_telemetry_files(match_ids, telemetry_dir))
+    stats = compute_combat_stats_from_events(account_id, documents)
+    stats["matches_analyzed"] = len(documents)
+    return stats

--- a/utils/display_combat_stats.py
+++ b/utils/display_combat_stats.py
@@ -1,0 +1,36 @@
+# ==============================
+# utils/display_combat_stats.py
+# ==============================
+
+
+def render_combat_stats(stats):
+    total_elims = stats["total_eliminations"]
+    total_deaths = stats["total_deaths"]
+    kd = total_elims / total_deaths if total_deaths else float(total_elims)
+    matches_analyzed = stats["matches_analyzed"]
+
+    print("=============================")
+    print("🎯 Summary - Combat Stats")
+    print("=============================")
+    print(f"Eliminations : {total_elims}")
+    print(f"Deaths       : {total_deaths}")
+    print(f"K/D Ratio    : {kd:.2f}")
+    plural = "es" if matches_analyzed != 1 else ""
+    print(f"(from {matches_analyzed} cached match{plural} with telemetry)")
+    print()
+
+    _render_breakdown("🔫 Eliminations Breakdown", stats["eliminations_breakdown"])
+    print()
+    _render_breakdown("💀 Deaths Breakdown", stats["deaths_breakdown"])
+
+
+def _render_breakdown(title, breakdown):
+    print("=============================")
+    print(title)
+    print("=============================")
+    if not breakdown:
+        print("No data in cached telemetry.")
+        return
+    width = max(len(name) for name in breakdown)
+    for name, count in breakdown.items():
+        print(f"{name:<{width}} : {count}")


### PR DESCRIPTION
## Summary
- Re-enables telemetry fetching (was disabled for ban-risk reasons; safe now that the request queue from #12 handles rate limiting), with conservative caps: 3 concurrent requests, 25 new matches per run max, so a heavy player's first run backfills gradually instead of bursting requests
- Mines cached telemetry for LogPlayerKillV2 events to compute total eliminations, deaths, and K/D ratio
- Adds a per-opponent breakdown of who was eliminated and who eliminations came from, sorted descending
- Environmental deaths (bluezone, falls, drowning) and suicides are excluded since they have no opposing player

## Test plan
- [x] Unit tests: `python -m unittest discover tests` (9 passing)
- [x] Live run against real cached telemetry (53 matches on disk): correct totals (35 eliminations, 55 deaths, 0.64 K/D) and full named breakdowns rendered correctly
- [x] Telemetry re-fetch confirmed conservative: 15 candidate matches, all already cached, 0 new network calls this run

Closes #4