### PR TITLE
Document testing standard, add coverage for untested pure-logic helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,20 @@ main.py
   until headers are seen. `/matches` and telemetry URLs are not
   rate-limited and bypass the queue.
 
+## Testing
+
+See [tests/README.md](tests/README.md) for the testing standard (unit vs.
+integration vs. live smoke test). Run the automated suite with:
+
+```bash
+python -m unittest discover tests
+```
+
+Any PR touching API-facing behavior (`api/` or code that changes what's
+sent to or parsed from a live response) also expects one manual smoke-test
+run (`python main.py <player>`) against the real API before merging - that
+step isn't part of the automated suite.
+
 ## Sample Output
 
 See [docs/sample-output.md](docs/sample-output.md) for a full example run.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,63 @@
+# Testing Standard
+
+Match the test type to what's actually being verified. The goal is
+high-value coverage, not a pile of narrow tests that are slow to maintain
+for marginal benefit. Nothing in this suite should ever make a real call to
+the PUBG API - that risks rate limits and account bans, and belongs to a
+manual smoke test, not automation.
+
+## Unit tests (bulk of the suite)
+
+Pure computation or parsing with no I/O: telemetry-derived stat tallying,
+rate-limiter throttling math, filename/URL/response parsing, display
+formatting helpers. Cheap to write, run in milliseconds, and pinpoint the
+exact broken function when they fail. Mock time/sleep rather than actually
+waiting (see `test_rate_limiter.py`).
+
+Examples: `test_combat_stats.py`, `test_display_stats_by_mode.py`,
+`test_display_match_history.py`, `test_player_index.py`,
+`test_telemetry_fetcher.py`.
+
+## Integration tests (mocked, narrow set)
+
+Module wiring where two pieces have to agree on a contract - e.g.
+`player_stats.py` calling through `rate_limiter.py`. Mock the network
+boundary (`aiohttp`), assert the right calls happened with the right args.
+Don't re-test logic already covered by that module's own unit tests here -
+just the handoff.
+
+Example: `test_player_stats.py`.
+
+## End-to-end / live smoke test
+
+A single documented manual run (`python main.py <player>`) against the real
+API. Expected once per PR that touches API-facing behavior (anything under
+`api/`, or code that changes what gets sent to or parsed from a live
+response) - not part of the automated suite.
+
+## Running the suite
+
+```bash
+python -m unittest discover tests
+```
+
+Requires a `.env` with `PUBG_API_KEY` set (see main README) -
+`api/telemetry_fetcher.py` raises at import time if it's missing, which
+means importing it for unit tests also requires the key to be present even
+though those tests don't make network calls.
+
+## Audit notes (as of the #17 pass)
+
+Existing tests already matched the standard - no miscategorized or
+duplicate tests found. Gaps filled in this pass: `normalize_filename`
+(`player_index.py`), `format_number` (`display_stats_by_mode.py`),
+`extract_match_ids_by_mode` (`display_match_history.py`), and
+`get_telemetry_url` (`telemetry_fetcher.py`) were pure-logic functions
+previously exercised only by manual runs.
+
+While auditing `format_number`, found that the `"Time Survived (min)"` row
+doesn't convert seconds to minutes like the other two survival-time rows do
+- the case-sensitive substring check (`"TimeSurvived"` vs. the actual key
+`"timeSurvived"`) doesn't match. Documented in
+`test_display_stats_by_mode.py`, tracked as a separate bug rather than
+fixed here.

--- a/tests/test_display_match_history.py
+++ b/tests/test_display_match_history.py
@@ -1,0 +1,45 @@
+##########
+# Unit Test for Match History parsing
+# from root of project: `python -m unittest discover tests`
+##########
+
+import unittest
+from utils.display_match_history import extract_match_ids_by_mode
+
+
+class TestExtractMatchIdsByMode(unittest.TestCase):
+
+    def test_groups_matches_by_normalized_mode(self):
+        stats = {
+            "data": {
+                "relationships": {
+                    "matchesSoloFPP": {"data": [{"id": "m1"}, {"id": "m2"}]},
+                    "matchesDuo": {"data": [{"id": "m3"}]},
+                    "roster": {"data": []},
+                }
+            }
+        }
+
+        result = extract_match_ids_by_mode(stats)
+
+        self.assertEqual(result["solo-fpp"], ["m1", "m2"])
+        self.assertEqual(result["duo"], ["m3"])
+        self.assertNotIn("roster", result)
+
+    def test_empty_matches_key_maps_to_unknown(self):
+        stats = {"data": {"relationships": {"matches": {"data": [{"id": "m1"}]}}}}
+
+        result = extract_match_ids_by_mode(stats)
+
+        self.assertEqual(result["unknown"], ["m1"])
+
+    def test_missing_data_key_yields_empty_list(self):
+        stats = {"data": {"relationships": {"matchesSquad": {}}}}
+
+        result = extract_match_ids_by_mode(stats)
+
+        self.assertEqual(result["squad"], [])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_display_stats_by_mode.py
+++ b/tests/test_display_stats_by_mode.py
@@ -1,0 +1,34 @@
+##########
+# Unit Test for Player Stats display formatting
+# from root of project: `python -m unittest discover tests`
+##########
+
+import unittest
+from utils.display_stats_by_mode import format_number
+
+
+class TestFormatNumber(unittest.TestCase):
+
+    def test_formats_small_int_with_commas(self):
+        self.assertEqual(format_number(1234), "1,234")
+
+    def test_formats_large_value_in_thousands(self):
+        self.assertEqual(format_number(150000), "150k")
+
+    def test_converts_time_survived_seconds_to_minutes(self):
+        self.assertEqual(format_number(120, key="longestTimeSurvived"), "2")
+
+    def test_time_survived_key_does_not_match_case_sensitive_check(self):
+        # Documents current behavior: "timeSurvived" (lowercase t) does not
+        # match the "TimeSurvived" substring check, so it's formatted as a
+        # plain number rather than converted from seconds to minutes. See
+        # the "Time Survived (min)" row mislabeling flagged in issue #17's
+        # test audit - tracked separately, not fixed here.
+        self.assertEqual(format_number(120, key="timeSurvived"), "120")
+
+    def test_non_numeric_value_defaults_to_zero(self):
+        self.assertEqual(format_number(None), "0")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_player_index.py
+++ b/tests/test_player_index.py
@@ -1,0 +1,23 @@
+##########
+# Unit Test for Player Index normalization
+# from root of project: `python -m unittest discover tests`
+##########
+
+import unittest
+from api.player_index import normalize_filename
+
+
+class TestNormalizeFilename(unittest.TestCase):
+
+    def test_lowercases_and_strips_spaces(self):
+        self.assertEqual(normalize_filename("Some Player"), "someplayer")
+
+    def test_strips_leading_and_trailing_whitespace(self):
+        self.assertEqual(normalize_filename("  Player  "), "player")
+
+    def test_handles_already_normalized_input(self):
+        self.assertEqual(normalize_filename("player"), "player")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_telemetry_fetcher.py
+++ b/tests/test_telemetry_fetcher.py
@@ -1,0 +1,36 @@
+##########
+# Unit Test for Telemetry URL parsing
+# from root of project: `python -m unittest discover tests`
+##########
+
+import unittest
+from api.telemetry_fetcher import get_telemetry_url
+
+
+class TestGetTelemetryUrl(unittest.TestCase):
+
+    def test_finds_telemetry_asset_url(self):
+        metadata = {
+            "included": [
+                {"type": "asset", "attributes": {"URL": "https://example.com/telemetry-data.json"}},
+                {"type": "roster", "attributes": {}},
+            ]
+        }
+
+        self.assertEqual(get_telemetry_url(metadata), "https://example.com/telemetry-data.json")
+
+    def test_ignores_non_asset_and_non_telemetry_entries(self):
+        metadata = {
+            "included": [
+                {"type": "asset", "attributes": {"URL": "https://example.com/other-asset.json"}},
+            ]
+        }
+
+        self.assertIsNone(get_telemetry_url(metadata))
+
+    def test_missing_included_key_returns_none(self):
+        self.assertIsNone(get_telemetry_url({}))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds tests/README.md defining unit vs. mocked-integration vs. manual-smoke-test guidance, linked from the main README
- Audits existing tests against the standard - all conform, nothing miscategorized or duplicated
- Adds unit tests for four pure-logic functions previously only exercised manually: normalize_filename, format_number, extract_match_ids_by_mode, get_telemetry_url
- Adds a one-line smoke-test expectation to the main README for API-facing PRs

Closes #17

## Test plan
- [x] `python -m unittest discover tests` - 23/23 pass in ~0.01s
- [x] No real network calls, no real sleep() waits in the suite