### PR TITLE
Add bot detection for last played match

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ playerstats/*.json
 match-telemetry/*.json
 matches/*.json
 player-index.json
+bot-index.json
 
 # macOS system files
 .DS_Store

--- a/api/bot_index.py
+++ b/api/bot_index.py
@@ -1,0 +1,55 @@
+# ==============================
+# api/bot_index.py
+# ==============================
+#
+# Separate from player_index.py on purpose: bots are never real teammates,
+# so this only tracks identity and encounter history for pattern analysis
+# (see issues #8, #9), not the social/rapport fields player_index carries.
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+BOT_INDEX_PATH = Path("bot-index.json")
+
+
+def load_bot_index():
+    if BOT_INDEX_PATH.exists():
+        with open(BOT_INDEX_PATH, "r") as f:
+            return json.load(f)
+    return {}
+
+
+def save_bot_index(index_data):
+    with open(BOT_INDEX_PATH, "w") as f:
+        json.dump(index_data, f, indent=2)
+
+
+def update_bot_index(bots, match_id):
+    """Record bots detected in a match into the persistent bot index.
+
+    `bots` is an {accountId: name} mapping, as returned by
+    utils.bot_detection.detect_bots.
+    """
+    index = load_bot_index()
+    today = datetime.now().strftime("%Y-%m-%d")
+
+    for account_id, name in bots.items():
+        if account_id not in index:
+            index[account_id] = {
+                "playername": name,
+                "first_seen": today,
+                "last_seen": today,
+                "matches_seen": [match_id],
+                "times_seen": 1,
+            }
+        else:
+            entry = index[account_id]
+            entry["playername"] = name
+            entry["last_seen"] = today
+            if match_id not in entry["matches_seen"]:
+                entry["matches_seen"].append(match_id)
+            entry["times_seen"] = len(entry["matches_seen"])
+
+    save_bot_index(index)
+    return index

--- a/main.py
+++ b/main.py
@@ -9,6 +9,9 @@ from utils.display_match_history import display_match_history
 from api.telemetry_fetcher import fetch_telemetry_for_matches
 from utils.combat_stats import compute_combat_stats
 from utils.display_combat_stats import render_combat_stats
+from utils.bot_detection import find_latest_match, detect_bots
+from utils.display_bot_stats import render_bot_summary
+from api.bot_index import update_bot_index
 import asyncio
 
 
@@ -51,6 +54,14 @@ async def _run(playername):
     print("\n\n")
     combat_stats = compute_combat_stats(player_id)
     render_combat_stats(combat_stats)
+
+    # Detect bots in the most recently played match and record them
+    print("\n\n")
+    latest_match_id, latest_events = find_latest_match()
+    if latest_match_id:
+        bots = detect_bots(latest_events)
+        update_bot_index(bots, latest_match_id)
+        render_bot_summary(latest_match_id, bots)
 
 def main():
     parser = argparse.ArgumentParser(description="Query and save PUBG lifetime player stats.")

--- a/tests/test_bot_detection.py
+++ b/tests/test_bot_detection.py
@@ -1,0 +1,88 @@
+##########
+# Unit Test for Bot Detection
+# from root of project: `python -m unittest discover tests`
+##########
+
+import json
+import os
+import tempfile
+import unittest
+
+from utils.bot_detection import detect_bots, find_latest_match
+
+
+def player_create_event(account_id, name, char_type="user", timestamp="2026-01-01T00:00:00.000Z"):
+    return {
+        "_T": "LogPlayerCreate",
+        "_D": timestamp,
+        "character": {"accountId": account_id, "name": name, "type": char_type},
+    }
+
+
+def match_start_event(timestamp):
+    return {"_T": "LogMatchStart", "_D": timestamp}
+
+
+class TestDetectBots(unittest.TestCase):
+
+    def test_identifies_ai_players_only(self):
+        events = [
+            player_create_event("account.human", "RealPlayer", char_type="user"),
+            player_create_event("account.bot", "BotName123", char_type="user_ai"),
+        ]
+
+        bots = detect_bots(events)
+
+        self.assertEqual(bots, {"account.bot": "BotName123"})
+
+    def test_no_bots_returns_empty_dict(self):
+        events = [player_create_event("account.human", "RealPlayer")]
+
+        self.assertEqual(detect_bots(events), {})
+
+    def test_ignores_events_without_account_id(self):
+        events = [{"_T": "LogPlayerCreate", "character": {"type": "user_ai", "name": "NoId"}}]
+
+        self.assertEqual(detect_bots(events), {})
+
+
+class TestFindLatestMatch(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+
+    def _write_match(self, match_id, timestamp, extra_events=None):
+        events = [match_start_event(timestamp)] + (extra_events or [])
+        path = os.path.join(self.tmpdir.name, f"{match_id}-telemetry.json")
+        with open(path, "w") as f:
+            json.dump(events, f)
+
+    def test_returns_match_with_latest_timestamp(self):
+        self._write_match("older-match", "2026-01-01T00:00:00.000Z")
+        self._write_match("newer-match", "2026-06-15T00:00:00.000Z")
+
+        match_id, events = find_latest_match(telemetry_dir=self.tmpdir.name)
+
+        self.assertEqual(match_id, "newer-match")
+        self.assertTrue(any(e.get("_T") == "LogMatchStart" for e in events))
+
+    def test_skips_files_without_match_start(self):
+        path = os.path.join(self.tmpdir.name, "no-start-telemetry.json")
+        with open(path, "w") as f:
+            json.dump([{"_T": "LogPlayerCreate"}], f)
+
+        match_id, events = find_latest_match(telemetry_dir=self.tmpdir.name)
+
+        self.assertIsNone(match_id)
+        self.assertIsNone(events)
+
+    def test_empty_directory_returns_none(self):
+        match_id, events = find_latest_match(telemetry_dir=self.tmpdir.name)
+
+        self.assertIsNone(match_id)
+        self.assertIsNone(events)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_bot_index.py
+++ b/tests/test_bot_index.py
@@ -1,0 +1,71 @@
+##########
+# Unit Test for Bot Index persistence
+# from root of project: `python -m unittest discover tests`
+##########
+
+import unittest
+from unittest.mock import patch
+
+from api.bot_index import update_bot_index
+
+BOTS = {"account.bot1": "BotName123"}
+
+
+class TestUpdateBotIndex(unittest.TestCase):
+
+    @patch("api.bot_index.save_bot_index")
+    @patch("api.bot_index.load_bot_index", return_value={})
+    def test_adds_new_bot_entry(self, mock_load, mock_save):
+        update_bot_index(BOTS, "match-1")
+
+        saved_index = mock_save.call_args.args[0]
+        entry = saved_index["account.bot1"]
+        self.assertEqual(entry["playername"], "BotName123")
+        self.assertEqual(entry["matches_seen"], ["match-1"])
+        self.assertEqual(entry["times_seen"], 1)
+        self.assertEqual(entry["first_seen"], entry["last_seen"])
+
+    @patch("api.bot_index.save_bot_index")
+    @patch("api.bot_index.load_bot_index")
+    def test_repeat_encounter_appends_match_and_increments_count(self, mock_load, mock_save):
+        mock_load.return_value = {
+            "account.bot1": {
+                "playername": "BotName123",
+                "first_seen": "2026-01-01",
+                "last_seen": "2026-01-01",
+                "matches_seen": ["match-1"],
+                "times_seen": 1,
+            }
+        }
+
+        update_bot_index(BOTS, "match-2")
+
+        saved_index = mock_save.call_args.args[0]
+        entry = saved_index["account.bot1"]
+        self.assertEqual(entry["matches_seen"], ["match-1", "match-2"])
+        self.assertEqual(entry["times_seen"], 2)
+        self.assertEqual(entry["first_seen"], "2026-01-01")
+
+    @patch("api.bot_index.save_bot_index")
+    @patch("api.bot_index.load_bot_index")
+    def test_same_match_seen_twice_does_not_duplicate(self, mock_load, mock_save):
+        mock_load.return_value = {
+            "account.bot1": {
+                "playername": "BotName123",
+                "first_seen": "2026-01-01",
+                "last_seen": "2026-01-01",
+                "matches_seen": ["match-1"],
+                "times_seen": 1,
+            }
+        }
+
+        update_bot_index(BOTS, "match-1")
+
+        saved_index = mock_save.call_args.args[0]
+        entry = saved_index["account.bot1"]
+        self.assertEqual(entry["matches_seen"], ["match-1"])
+        self.assertEqual(entry["times_seen"], 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/utils/bot_detection.py
+++ b/utils/bot_detection.py
@@ -1,0 +1,55 @@
+# ==============================
+# utils/bot_detection.py
+# ==============================
+import glob
+import json
+import os
+
+TELEMETRY_DIR = "match-telemetry"
+
+
+def _load_telemetry_files(telemetry_dir=TELEMETRY_DIR):
+    for path in glob.glob(os.path.join(telemetry_dir, "*-telemetry.json")):
+        match_id = os.path.basename(path).replace("-telemetry.json", "")
+        with open(path, "r") as f:
+            yield match_id, json.load(f)
+
+
+def find_latest_match(telemetry_dir=TELEMETRY_DIR):
+    """Return (match_id, events) for the most recently played cached match.
+
+    Recency is read from each match's LogMatchStart timestamp rather than
+    match ID ordering, since PUBG match IDs aren't sortable by time.
+    """
+    latest_timestamp = None
+    latest_match_id = None
+    latest_events = None
+
+    for match_id, events in _load_telemetry_files(telemetry_dir):
+        start_event = next((e for e in events if e.get("_T") == "LogMatchStart"), None)
+        if not start_event:
+            continue
+        timestamp = start_event.get("_D")
+        if timestamp and (latest_timestamp is None or timestamp > latest_timestamp):
+            latest_timestamp = timestamp
+            latest_match_id = match_id
+            latest_events = events
+
+    return latest_match_id, latest_events
+
+
+def detect_bots(telemetry_events):
+    """Return {accountId: name} for AI-controlled players in a match.
+
+    Bots are identified by "type": "user_ai" on LogPlayerCreate's character.
+    """
+    bots = {}
+    for event in telemetry_events:
+        if event.get("_T") != "LogPlayerCreate":
+            continue
+        character = event.get("character") or {}
+        if character.get("type") == "user_ai":
+            account_id = character.get("accountId")
+            if account_id:
+                bots[account_id] = character.get("name", "Unknown")
+    return bots

--- a/utils/display_bot_stats.py
+++ b/utils/display_bot_stats.py
@@ -1,0 +1,19 @@
+# ==============================
+# utils/display_bot_stats.py
+# ==============================
+
+
+def render_bot_summary(match_id, bots):
+    print("=============================")
+    print("🤖 Bot Detection - Last Match")
+    print("=============================")
+    print(f"Match ID: {match_id}")
+    print(f"Bots Detected: {len(bots)}")
+    print()
+
+    if not bots:
+        print("No AI players found in this match's telemetry.")
+        return
+
+    for account_id, name in bots.items():
+        print(f"  • {name}  ({account_id})")


### PR DESCRIPTION
## Summary
- Identifies AI-controlled players in the most recently played cached match via the "user_ai" type flag PUBG's telemetry sets on LogPlayerCreate events
- "Last match" is resolved by LogMatchStart timestamp, not match ID ordering
- Persists detected bots to a separate bot-index.json (gitignored), tracking identity and encounter history across matches, independent of player-index.json's social/rapport fields
- Movement and drop-pattern analysis is out of scope here and belongs to #8/#9; bot-index.json's account IDs are the join key for that future work

Closes #11

## Test plan
- [x] `python -m unittest discover tests` - 32/32 pass
- [x] Verified end-to-end against real cached telemetry: correctly found the latest match and identified 55 bots by name and account ID, with bot-index.json written and populated as expected