### PR TITLE
Add per-teammate last match brief

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,6 +12,8 @@ from utils.display_combat_stats import render_combat_stats
 from utils.bot_detection import find_latest_match, detect_bots
 from utils.display_bot_stats import render_bot_summary
 from api.bot_index import update_bot_index
+from utils.last_match_brief import find_latest_match_for_player, compute_last_match_brief
+from utils.display_last_match_brief import render_last_match_brief
 import asyncio
 
 
@@ -55,9 +57,18 @@ async def _run(playername):
     combat_stats = compute_combat_stats(player_id)
     render_combat_stats(combat_stats)
 
-    # Detect bots in the most recently played match and record them
+    # Last Match section: brief for this player, then bot detection for
+    # whichever cached match is most recent overall (a stand-in for "your"
+    # last match until Phase 3 auto-detection establishes a real self-identity)
     print("\n\n")
     latest_match_id, latest_events = find_latest_match()
+
+    player_match_id, player_events = find_latest_match_for_player(player_id)
+    if player_match_id:
+        brief = compute_last_match_brief(player_id, player_match_id, player_events)
+        played_with_you = (player_match_id == latest_match_id) if latest_match_id else None
+        render_last_match_brief(playername, brief, played_with_you)
+
     if latest_match_id:
         bots = detect_bots(latest_events)
         update_bot_index(bots, latest_match_id)

--- a/tests/test_last_match_brief.py
+++ b/tests/test_last_match_brief.py
@@ -1,0 +1,144 @@
+##########
+# Unit Test for Last Match Brief
+# from root of project: `python -m unittest discover tests`
+##########
+
+import json
+import os
+import tempfile
+import unittest
+
+from utils.last_match_brief import (
+    compute_last_match_brief,
+    find_latest_match_for_player,
+    player_present_in_match,
+)
+
+ME = "account.me"
+KILLER = "account.killer"
+
+
+def match_start_event(timestamp="2026-01-01T00:00:00.000Z"):
+    return {"_T": "LogMatchStart", "_D": timestamp}
+
+
+def match_end_event(entries):
+    return {"_T": "LogMatchEnd", "characters": entries}
+
+
+def match_end_entry(account_id, ranking):
+    return {"character": {"accountId": account_id, "ranking": ranking}}
+
+
+def create_event(account_id, timestamp="2026-01-01T00:00:00.000Z"):
+    return {"_T": "LogPlayerCreate", "_D": timestamp, "character": {"accountId": account_id, "type": "user"}}
+
+
+def kill_event(killer_id, killer_name, victim_id, weapon, distance_cm, timestamp, is_suicide=False):
+    return {
+        "_T": "LogPlayerKillV2",
+        "_D": timestamp,
+        "isSuicide": is_suicide,
+        "killer": {"accountId": killer_id, "name": killer_name, "type": "user"},
+        "victim": {"accountId": victim_id, "type": "user"},
+        "killerDamageInfo": {"damageCauserName": weapon, "distance": distance_cm},
+    }
+
+
+class TestComputeLastMatchBrief(unittest.TestCase):
+
+    def test_death_populates_time_alive_and_death_info(self):
+        events = [
+            match_start_event("2026-01-01T00:00:00.000Z"),
+            create_event(ME),
+            kill_event(KILLER, "Rival", ME, "WeapAUG_C", 2090.0, "2026-01-01T00:05:00.000Z"),
+            match_end_event([match_end_entry(ME, 42)]),
+        ]
+
+        brief = compute_last_match_brief(ME, "match-1", events)
+
+        self.assertEqual(brief["round_rank"], 42)
+        self.assertEqual(brief["time_alive_seconds"], 300)
+        self.assertEqual(brief["kill_count"], 0)
+        self.assertIsNone(brief["most_used_weapon"])
+        self.assertEqual(brief["death_info"], {"killed_by": "Rival", "weapon": "AUG", "distance_m": 20.9})
+
+    def test_survivor_has_no_death_info_and_uses_match_end_time(self):
+        events = [
+            match_start_event("2026-01-01T00:00:00.000Z"),
+            create_event(ME),
+            kill_event(ME, "Me", "account.victim1", "WeapVSS_C", 1000.0, "2026-01-01T00:10:00.000Z"),
+            kill_event(ME, "Me", "account.victim2", "WeapVSS_C", 1500.0, "2026-01-01T00:12:00.000Z"),
+            match_end_event([match_end_entry(ME, 1)]),
+        ]
+        events[-1]["_D"] = "2026-01-01T00:25:00.000Z"
+
+        brief = compute_last_match_brief(ME, "match-1", events)
+
+        self.assertEqual(brief["round_rank"], 1)
+        self.assertEqual(brief["time_alive_seconds"], 1500)
+        self.assertEqual(brief["kill_count"], 2)
+        self.assertEqual(brief["most_used_weapon"], "VSS")
+        self.assertIsNone(brief["death_info"])
+
+    def test_most_used_weapon_picks_highest_count(self):
+        events = [
+            match_start_event(),
+            create_event(ME),
+            kill_event(ME, "Me", "account.v1", "WeapAKM_C", 500.0, "2026-01-01T00:01:00.000Z"),
+            kill_event(ME, "Me", "account.v2", "WeapAKM_C", 500.0, "2026-01-01T00:02:00.000Z"),
+            kill_event(ME, "Me", "account.v3", "WeapKar98k_C", 500.0, "2026-01-01T00:03:00.000Z"),
+            match_end_event([match_end_entry(ME, 3)]),
+        ]
+
+        brief = compute_last_match_brief(ME, "match-1", events)
+
+        self.assertEqual(brief["most_used_weapon"], "AKM")
+
+
+class TestPlayerPresentInMatch(unittest.TestCase):
+
+    def test_true_when_account_has_create_event(self):
+        self.assertTrue(player_present_in_match(ME, [create_event(ME)]))
+
+    def test_false_when_absent(self):
+        self.assertFalse(player_present_in_match(ME, [create_event(KILLER)]))
+
+
+class TestFindLatestMatchForPlayer(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+
+    def _write_match(self, match_id, timestamp, account_id):
+        events = [match_start_event(timestamp), create_event(account_id, timestamp)]
+        path = os.path.join(self.tmpdir.name, f"{match_id}-telemetry.json")
+        with open(path, "w") as f:
+            json.dump(events, f)
+
+    def test_only_considers_matches_player_appears_in(self):
+        self._write_match("with-me", "2026-01-01T00:00:00.000Z", ME)
+        self._write_match("without-me", "2026-06-01T00:00:00.000Z", KILLER)
+
+        match_id, events = find_latest_match_for_player(ME, telemetry_dir=self.tmpdir.name)
+
+        self.assertEqual(match_id, "with-me")
+
+    def test_picks_latest_among_matches_player_appears_in(self):
+        self._write_match("older", "2026-01-01T00:00:00.000Z", ME)
+        self._write_match("newer", "2026-03-01T00:00:00.000Z", ME)
+
+        match_id, events = find_latest_match_for_player(ME, telemetry_dir=self.tmpdir.name)
+
+        self.assertEqual(match_id, "newer")
+
+    def test_no_matches_returns_none(self):
+        match_id, events = find_latest_match_for_player(ME, telemetry_dir=self.tmpdir.name)
+
+        self.assertIsNone(match_id)
+        self.assertIsNone(events)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/utils/display_last_match_brief.py
+++ b/utils/display_last_match_brief.py
@@ -1,0 +1,31 @@
+# ==============================
+# utils/display_last_match_brief.py
+# ==============================
+
+
+def render_last_match_brief(playername, brief, played_with_you=None):
+    print("=============================")
+    print(f"📋 Last Match Brief - {playername}")
+    print("=============================")
+    print(f"Match ID   : {brief['match_id']}")
+    print(f"Round Rank : {brief['round_rank'] if brief['round_rank'] is not None else 'Unknown'}")
+
+    time_alive = brief["time_alive_seconds"]
+    if time_alive is not None:
+        minutes, seconds = divmod(time_alive, 60)
+        print(f"Time Alive : {minutes}m {seconds}s")
+    else:
+        print("Time Alive : Unknown")
+
+    print(f"Kills      : {brief['kill_count']}")
+    print(f"Top Weapon : {brief['most_used_weapon'] or '-'}")
+
+    death_info = brief["death_info"]
+    if death_info:
+        print(f"Died To    : {death_info['killed_by']} ({death_info['weapon']}) from {death_info['distance_m']}m")
+    else:
+        print("Died To    : Survived to match end")
+
+    if played_with_you is not None:
+        print(f"In your last shared match: {'Yes' if played_with_you else 'No'}")
+    print()

--- a/utils/last_match_brief.py
+++ b/utils/last_match_brief.py
@@ -1,0 +1,143 @@
+# ==============================
+# utils/last_match_brief.py
+# ==============================
+import glob
+import json
+import os
+from datetime import datetime
+
+TELEMETRY_DIR = "match-telemetry"
+
+WEAPON_PREFIX = "Weap"
+MELEE_CAUSERS = {"PlayerFemale_A", "PlayerMale_A"}
+VEHICLE_HINTS = ("Uaz", "Dacia", "Mirado", "Coupe", "PickupTruck", "Buggy", "Motorbike", "Rony", "Van", "Scooter")
+_TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
+
+
+def _load_telemetry_files(telemetry_dir=TELEMETRY_DIR):
+    for path in glob.glob(os.path.join(telemetry_dir, "*-telemetry.json")):
+        match_id = os.path.basename(path).replace("-telemetry.json", "")
+        with open(path, "r") as f:
+            yield match_id, json.load(f)
+
+
+def find_latest_match_for_player(account_id, telemetry_dir=TELEMETRY_DIR):
+    """Return (match_id, events) for the player's most recently played cached match.
+
+    Same LogMatchStart-timestamp approach as bot_detection.find_latest_match,
+    but scoped to matches the given account actually appears in.
+    """
+    latest_timestamp = None
+    latest_match_id = None
+    latest_events = None
+
+    for match_id, events in _load_telemetry_files(telemetry_dir):
+        if not player_present_in_match(account_id, events):
+            continue
+
+        start_event = next((e for e in events if e.get("_T") == "LogMatchStart"), None)
+        if not start_event:
+            continue
+
+        timestamp = start_event.get("_D")
+        if timestamp and (latest_timestamp is None or timestamp > latest_timestamp):
+            latest_timestamp = timestamp
+            latest_match_id = match_id
+            latest_events = events
+
+    return latest_match_id, latest_events
+
+
+def player_present_in_match(account_id, events):
+    return any(
+        e.get("_T") == "LogPlayerCreate" and (e.get("character") or {}).get("accountId") == account_id
+        for e in events
+    )
+
+
+def _clean_weapon_name(causer_name):
+    """Best-effort readable name for a telemetry damageCauserName.
+
+    Covers guns (the common case) precisely; vehicles, throwables, and
+    melee get a general label; anything unrecognized falls back to a
+    de-prefixed, space-separated version of the raw asset name rather than
+    a hard failure.
+    """
+    if not causer_name:
+        return "Unknown"
+
+    name = causer_name[:-2] if causer_name.endswith("_C") else causer_name
+
+    if name.startswith(WEAPON_PREFIX):
+        return name[len(WEAPON_PREFIX):]
+    if name in MELEE_CAUSERS:
+        return "Melee"
+    if "Grenade" in name:
+        return "Grenade"
+    if "Molotov" in name:
+        return "Molotov Cocktail"
+    if any(hint in name for hint in VEHICLE_HINTS):
+        return "Vehicle"
+
+    return name.replace("BP_", "").replace("_", " ").strip() or "Unknown"
+
+
+def _parse_timestamp(value):
+    return datetime.strptime(value, _TIMESTAMP_FORMAT) if value else None
+
+
+def compute_last_match_brief(account_id, match_id, events):
+    match_start = next((e for e in events if e.get("_T") == "LogMatchStart"), None)
+    match_end = next((e for e in events if e.get("_T") == "LogMatchEnd"), None)
+    start_ts = _parse_timestamp(match_start.get("_D")) if match_start else None
+
+    round_rank = None
+    if match_end:
+        entry = next(
+            (c for c in match_end.get("characters", []) if (c.get("character") or {}).get("accountId") == account_id),
+            None,
+        )
+        if entry:
+            round_rank = entry["character"].get("ranking")
+
+    kill_count = 0
+    weapon_counts = {}
+    death_info = None
+    death_ts = None
+
+    for event in events:
+        if event.get("_T") != "LogPlayerKillV2" or event.get("isSuicide"):
+            continue
+
+        killer = event.get("killer") or {}
+        victim = event.get("victim") or {}
+        if killer.get("type") != "user" or victim.get("type") != "user":
+            continue
+
+        if killer.get("accountId") == account_id and victim.get("accountId") != account_id:
+            kill_count += 1
+            weapon = _clean_weapon_name((event.get("killerDamageInfo") or {}).get("damageCauserName"))
+            weapon_counts[weapon] = weapon_counts.get(weapon, 0) + 1
+
+        if victim.get("accountId") == account_id and killer.get("accountId") != account_id:
+            kdi = event.get("killerDamageInfo") or {}
+            death_info = {
+                "killed_by": killer.get("name", "Unknown"),
+                "weapon": _clean_weapon_name(kdi.get("damageCauserName")),
+                "distance_m": round(kdi.get("distance", 0) / 100, 1),
+            }
+            death_ts = _parse_timestamp(event.get("_D"))
+
+    most_used_weapon = max(weapon_counts, key=weapon_counts.get) if weapon_counts else None
+
+    end_ts = death_ts or (_parse_timestamp(match_end.get("_D")) if match_end else None)
+    time_alive_seconds = int((end_ts - start_ts).total_seconds()) if start_ts and end_ts else None
+
+    return {
+        "match_id": match_id,
+        "round_rank": round_rank,
+        "time_alive_seconds": time_alive_seconds,
+        "kill_count": kill_count,
+        "most_used_weapon": most_used_weapon,
+        "death_info": death_info,
+    }


### PR DESCRIPTION
## Summary
- Summarizes a player's most recently played cached match: round rank, time alive, kill count, most-used weapon, and death info (killer, weapon, distance)
- Round rank comes from LogMatchEnd's per-character team ranking; time alive is derived from LogMatchStart to death (or match-end) timestamp
- Weapon names are cleaned from raw telemetry asset names (e.g. WeapAUG_C -> AUG) with a general fallback for vehicles/throwables/melee, not a hardcoded per-weapon lookup table
- Flags whether the player was present in the most recent match across the whole cache, as a stand-in for "your last match" until Phase 3 auto-detection establishes a real self-identity - noted inline as a placeholder, not a final design
- Wired into main.py alongside bot detection as a combined "Last Match" section, after the aggregate lifetime/combat stats

Closes #13

## Test plan
- [x] `python -m unittest discover tests` - 40/40 pass
- [x] Verified end-to-end with a live run (`python main.py 7h3Cr0`) against the real API - Last Match Brief renders correctly alongside Bot Detection
- [x] Spot-checked against real cached telemetry for edge cases: early death with 0 kills, and a 17-kill win with no death event