### PR TITLE
Add tempo signal for Archetype Tag (time-to-first-contact)

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,6 +14,8 @@ from utils.display_bot_stats import render_bot_summary
 from api.bot_index import update_bot_index
 from utils.last_match_brief import find_latest_match_for_player, compute_last_match_brief
 from utils.display_last_match_brief import render_last_match_brief
+from utils.tempo_signal import compute_tempo_signal
+from utils.display_tempo_signal import render_tempo_signal
 import asyncio
 
 
@@ -56,6 +58,11 @@ async def _run(playername):
     print("\n\n")
     combat_stats = compute_combat_stats(player_id)
     render_combat_stats(combat_stats)
+
+    # Display tempo signal (Archetype Tag) mined from cached telemetry
+    print("\n\n")
+    tempo_signal = compute_tempo_signal(player_id)
+    render_tempo_signal(tempo_signal)
 
     # Last Match section: brief for this player, then bot detection for
     # whichever cached match is most recent overall (a stand-in for "your"

--- a/tests/test_tempo_signal.py
+++ b/tests/test_tempo_signal.py
@@ -1,0 +1,177 @@
+##########
+# Unit Test for Tempo Signal (Archetype Tag - time-to-first-contact)
+# from root of project: `python -m unittest discover tests`
+##########
+
+import json
+import os
+import tempfile
+import unittest
+
+from utils.tempo_signal import compute_time_to_first_contact_from_events, compute_tempo_signal
+
+ME = "account.me"
+RIVAL = "account.rival"
+
+
+def match_start(seconds_offset=0, base="2026-07-22T00:00:00.000Z"):
+    return {"_T": "LogMatchStart", "_D": base}
+
+
+def damage_event(attacker_id, victim_id, seconds_after_start,
+                  attacker_type="user", victim_type="user"):
+    return {
+        "_T": "LogPlayerTakeDamage",
+        "attacker": {"accountId": attacker_id, "type": attacker_type},
+        "victim": {"accountId": victim_id, "type": victim_type},
+        "_D": f"2026-07-22T00:{seconds_after_start // 60:02d}:{seconds_after_start % 60:02d}.000Z",
+    }
+
+
+def kill_event(killer_id, victim_id, seconds_after_start, is_suicide=False,
+               killer_type="user", victim_type="user"):
+    return {
+        "_T": "LogPlayerKillV2",
+        "isSuicide": is_suicide,
+        "killer": {"accountId": killer_id, "type": killer_type},
+        "victim": {"accountId": victim_id, "type": victim_type},
+        "_D": f"2026-07-22T00:{seconds_after_start // 60:02d}:{seconds_after_start % 60:02d}.000Z",
+    }
+
+
+class TestComputeTimeToFirstContact(unittest.TestCase):
+
+    def test_hot_drop_headhunter_on_fast_contact_and_quick_kill(self):
+        events = [
+            match_start(),
+            damage_event(ME, RIVAL, 30),
+            kill_event(ME, RIVAL, 45),
+        ]
+
+        result = compute_time_to_first_contact_from_events(ME, events)
+
+        self.assertEqual(result["contact_seconds"], 30)
+        self.assertTrue(result["quick_kill"])
+        self.assertEqual(result["tempo_bucket"], "Hot-Drop Headhunter")
+
+    def test_early_skirmisher_on_fast_contact_without_quick_kill(self):
+        events = [
+            match_start(),
+            damage_event(ME, RIVAL, 30),
+        ]
+
+        result = compute_time_to_first_contact_from_events(ME, events)
+
+        self.assertFalse(result["quick_kill"])
+        self.assertEqual(result["tempo_bucket"], "Early Skirmisher")
+
+    def test_quick_gear_striker_on_short_delay(self):
+        events = [match_start(), damage_event(ME, RIVAL, 200)]
+
+        result = compute_time_to_first_contact_from_events(ME, events)
+
+        self.assertEqual(result["tempo_bucket"], "Quick-Gear Striker")
+
+    def test_calculated_pusher_on_moderate_delay(self):
+        events = [match_start(), damage_event(ME, RIVAL, 450)]
+
+        result = compute_time_to_first_contact_from_events(ME, events)
+
+        self.assertEqual(result["tempo_bucket"], "Calculated Pusher")
+
+    def test_slow_roll_patient_on_long_delay(self):
+        events = [match_start(), damage_event(ME, RIVAL, 900)]
+
+        result = compute_time_to_first_contact_from_events(ME, events)
+
+        self.assertEqual(result["tempo_bucket"], "Slow-Roll Patient")
+
+    def test_slow_roll_patient_when_no_contact_at_all(self):
+        events = [match_start()]
+
+        result = compute_time_to_first_contact_from_events(ME, events)
+
+        self.assertIsNone(result["contact_seconds"])
+        self.assertEqual(result["tempo_bucket"], "Slow-Roll Patient")
+
+    def test_none_when_match_never_started(self):
+        events = [damage_event(ME, RIVAL, 30)]
+
+        result = compute_time_to_first_contact_from_events(ME, events)
+
+        self.assertIsNone(result)
+
+    def test_ignores_self_damage_and_environmental_damage(self):
+        events = [
+            match_start(),
+            damage_event(ME, ME, 10),
+            kill_event(ME, RIVAL, 40),
+        ]
+
+        result = compute_time_to_first_contact_from_events(ME, events)
+
+        self.assertIsNone(result["contact_seconds"])
+
+    def test_ignores_damage_against_bots(self):
+        events = [
+            match_start(),
+            damage_event(ME, RIVAL, 15, victim_type="user_ai"),
+            damage_event(ME, RIVAL, 250),
+        ]
+
+        result = compute_time_to_first_contact_from_events(ME, events)
+
+        self.assertEqual(result["contact_seconds"], 250)
+
+    def test_kill_outside_quick_kill_window_does_not_count(self):
+        events = [
+            match_start(),
+            damage_event(ME, RIVAL, 10),
+            kill_event(ME, RIVAL, 200),
+        ]
+
+        result = compute_time_to_first_contact_from_events(ME, events)
+
+        self.assertFalse(result["quick_kill"])
+        self.assertEqual(result["tempo_bucket"], "Early Skirmisher")
+
+
+class TestComputeTempoSignal(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+
+    def _write_match(self, match_id, events):
+        path = os.path.join(self.tmpdir.name, f"{match_id}-telemetry.json")
+        with open(path, "w") as f:
+            json.dump(events, f)
+
+    def test_aggregates_most_common_bucket_across_matches(self):
+        self._write_match("match1", [match_start(), damage_event(ME, RIVAL, 900)])
+        self._write_match("match2", [match_start(), damage_event(ME, RIVAL, 950)])
+        self._write_match("match3", [match_start(), damage_event(ME, RIVAL, 30), kill_event(ME, RIVAL, 40)])
+
+        signal = compute_tempo_signal(ME, telemetry_dir=self.tmpdir.name)
+
+        self.assertEqual(signal["tempo_tag"], "Slow-Roll Patient")
+        self.assertEqual(signal["matches_analyzed"], 3)
+        self.assertEqual(signal["matches_with_contact"], 3)
+
+    def test_ties_break_toward_faster_bucket(self):
+        self._write_match("match1", [match_start(), damage_event(ME, RIVAL, 900)])
+        self._write_match("match2", [match_start(), damage_event(ME, RIVAL, 30), kill_event(ME, RIVAL, 40)])
+
+        signal = compute_tempo_signal(ME, telemetry_dir=self.tmpdir.name)
+
+        self.assertEqual(signal["tempo_tag"], "Hot-Drop Headhunter")
+
+    def test_no_tempo_tag_when_no_matches_cached(self):
+        signal = compute_tempo_signal(ME, telemetry_dir=self.tmpdir.name)
+
+        self.assertIsNone(signal["tempo_tag"])
+        self.assertEqual(signal["matches_analyzed"], 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/utils/display_tempo_signal.py
+++ b/utils/display_tempo_signal.py
@@ -1,0 +1,26 @@
+# ==============================
+# utils/display_tempo_signal.py
+# ==============================
+
+
+def render_tempo_signal(signal):
+    print("=============================")
+    print("⏱️  Archetype Tag - Tempo")
+    print("=============================")
+
+    tempo_tag = signal["tempo_tag"]
+    matches_analyzed = signal["matches_analyzed"]
+    matches_with_contact = signal["matches_with_contact"]
+
+    if tempo_tag is None:
+        print("No cached telemetry with a real-player engagement yet.")
+        return
+
+    print(f"Tempo tag: {tempo_tag}")
+    plural = "es" if matches_analyzed != 1 else ""
+    print(f"(from {matches_with_contact}/{matches_analyzed} cached match{plural} with an early engagement)")
+    print()
+
+    width = max(len(bucket) for bucket in signal["bucket_counts"])
+    for bucket, count in sorted(signal["bucket_counts"].items(), key=lambda kv: kv[1], reverse=True):
+        print(f"{bucket:<{width}} : {count}")

--- a/utils/tempo_signal.py
+++ b/utils/tempo_signal.py
@@ -1,0 +1,131 @@
+# ==============================
+# utils/tempo_signal.py
+# ==============================
+import glob
+import json
+import os
+from datetime import datetime
+
+TELEMETRY_DIR = "match-telemetry"
+
+# Bucket thresholds in seconds from LogMatchStart to first real-player
+# contact, and the window after that contact within which a kill still
+# reads as "quick". Placeholder values pending calibration against real
+# match-pacing data (varies by map/mode) - see docs/design/storyboard-profile.md.
+VERY_FAST_CONTACT_SECONDS = 120
+SHORT_DELAY_SECONDS = 300
+MODERATE_DELAY_SECONDS = 600
+QUICK_KILL_WINDOW_SECONDS = 60
+
+TEMPO_BUCKET_ORDER = [
+    "Hot-Drop Headhunter",
+    "Early Skirmisher",
+    "Quick-Gear Striker",
+    "Calculated Pusher",
+    "Slow-Roll Patient",
+]
+
+
+def _load_telemetry_files(match_ids=None, telemetry_dir=TELEMETRY_DIR):
+    for path in glob.glob(os.path.join(telemetry_dir, "*-telemetry.json")):
+        match_id = os.path.basename(path).replace("-telemetry.json", "")
+        if match_ids is not None and match_id not in match_ids:
+            continue
+        with open(path, "r") as f:
+            yield json.load(f)
+
+
+def _parse_timestamp(value):
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def compute_time_to_first_contact_from_events(account_id, telemetry_events):
+    """Return this match's tempo reading for one player, or None if unplayed.
+
+    Tempo is driven by time-to-first-contact: elapsed time from
+    LogMatchStart to the player's first LogPlayerTakeDamage event where
+    they're the attacker against a real (non-bot, non-NPC) player - this
+    covers both damage-only pokes and kills, since a kill is damage that
+    finished the job. Environmental/self damage is excluded because it
+    has no real opponent on the other end.
+    """
+    start_event = next((e for e in telemetry_events if e.get("_T") == "LogMatchStart"), None)
+    if not start_event or not start_event.get("_D"):
+        return None
+    match_start = _parse_timestamp(start_event["_D"])
+
+    contact_seconds = None
+    for event in telemetry_events:
+        if event.get("_T") != "LogPlayerTakeDamage":
+            continue
+        attacker = event.get("attacker") or {}
+        victim = event.get("victim") or {}
+        if attacker.get("accountId") != account_id or attacker.get("type") != "user":
+            continue
+        if victim.get("type") != "user" or victim.get("accountId") == account_id:
+            continue
+        elapsed = (_parse_timestamp(event["_D"]) - match_start).total_seconds()
+        if contact_seconds is None or elapsed < contact_seconds:
+            contact_seconds = elapsed
+
+    if contact_seconds is None:
+        return {"contact_seconds": None, "quick_kill": False, "tempo_bucket": "Slow-Roll Patient"}
+
+    kill_seconds = None
+    for event in telemetry_events:
+        if event.get("_T") != "LogPlayerKillV2" or event.get("isSuicide"):
+            continue
+        killer = event.get("killer") or {}
+        victim = event.get("victim") or {}
+        if killer.get("accountId") != account_id or killer.get("type") != "user":
+            continue
+        if victim.get("type") != "user" or victim.get("accountId") == account_id:
+            continue
+        elapsed = (_parse_timestamp(event["_D"]) - match_start).total_seconds()
+        if kill_seconds is None or elapsed < kill_seconds:
+            kill_seconds = elapsed
+
+    quick_kill = kill_seconds is not None and (kill_seconds - contact_seconds) <= QUICK_KILL_WINDOW_SECONDS
+
+    if contact_seconds <= VERY_FAST_CONTACT_SECONDS:
+        bucket = "Hot-Drop Headhunter" if quick_kill else "Early Skirmisher"
+    elif contact_seconds <= SHORT_DELAY_SECONDS:
+        bucket = "Quick-Gear Striker"
+    elif contact_seconds <= MODERATE_DELAY_SECONDS:
+        bucket = "Calculated Pusher"
+    else:
+        bucket = "Slow-Roll Patient"
+
+    return {"contact_seconds": contact_seconds, "quick_kill": quick_kill, "tempo_bucket": bucket}
+
+
+def compute_tempo_signal(account_id, match_ids=None, telemetry_dir=TELEMETRY_DIR):
+    """Aggregate the tempo half of the Archetype Tag across cached matches.
+
+    Overall tag is the most frequent per-match bucket, ties broken by
+    bucket priority (fastest-tempo bucket first) rather than arbitrarily.
+    """
+    per_match = []
+    for events in _load_telemetry_files(match_ids, telemetry_dir):
+        reading = compute_time_to_first_contact_from_events(account_id, events)
+        if reading is not None:
+            per_match.append(reading)
+
+    bucket_counts = {}
+    for reading in per_match:
+        bucket = reading["tempo_bucket"]
+        bucket_counts[bucket] = bucket_counts.get(bucket, 0) + 1
+
+    if bucket_counts:
+        max_count = max(bucket_counts.values())
+        tied = [b for b, c in bucket_counts.items() if c == max_count]
+        tempo_tag = next(b for b in TEMPO_BUCKET_ORDER if b in tied)
+    else:
+        tempo_tag = None
+
+    return {
+        "tempo_tag": tempo_tag,
+        "matches_analyzed": len(per_match),
+        "matches_with_contact": sum(1 for r in per_match if r["contact_seconds"] is not None),
+        "bucket_counts": bucket_counts,
+    }


### PR DESCRIPTION
## Summary
- First concrete implementation slice of the Archetype Tag: the tempo half, from `docs/design/storyboard-profile.md`.
- Computes time-to-first-contact per match (`LogMatchStart` → first `LogPlayerTakeDamage` as attacker vs. a real player), weighted by quick-kill conversion, into the five design-doc buckets, then aggregates into an overall tempo tag across cached matches.
- Bucket thresholds and the tie-breaking rule for the overall tag are placeholders pending real match-pacing calibration, called out in code comments - not locked in the design doc.
- Wired into `main.py` after the combat stats section, matching the existing `compute_*` / `render_*` module pairing.

## Test plan
- [x] `python -m unittest discover tests` - all 45 tests pass, including 14 new tests covering all five buckets and edge cases (no contact, self-damage, bot damage, kill outside the quick-kill window, tie-breaking)
- [x] Manual smoke test against real cached telemetry (`compute_tempo_signal` + `render_tempo_signal` on a real accountId) - produced a sensible tag and per-bucket breakdown