### PR TITLE
Add Windows one-click setup and environment doctor script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+PUBG_API_KEY=your_api_key_here
+
+# Optional: default rate limit (requests/minute) for /players and /seasons
+# calls, used until the API's response headers take over. Defaults to 10.
+PUBG_RATE_LIMIT_PER_MINUTE=10
+
+# Optional: how many telemetry files fetch concurrently. Defaults to 3.
+TELEMETRY_CONCURRENCY=3
+
+# Optional: cap on new telemetry files fetched per run. Defaults to 25.
+TELEMETRY_MAX_NEW_PER_RUN=25

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ where this is headed.
 
 ## Getting Started
 
+### macOS / dev machine
+
 1. Clone the repo and set up a virtual environment:
 
 ```bash
@@ -35,21 +37,46 @@ source .venv/bin/activate
 pip install -r requirements.txt  # python-dotenv, aiohttp
 ```
 
-3. Set up a `.env` file with your PUBG API key:
+3. Set up a `.env` file with your PUBG API key - copy `.env.example` to
+   `.env` and fill in `PUBG_API_KEY`.
 
+4. Confirm the environment is healthy:
+
+```bash
+python doctor.py
 ```
-PUBG_API_KEY=your_api_key_here
 
-# Optional: default rate limit (requests/minute) for /players and /seasons
-# calls, used until the API's response headers take over. Defaults to 10.
-PUBG_RATE_LIMIT_PER_MINUTE=10
-```
-
-4. Run it against a player name:
+5. Run it against a player name:
 
 ```bash
 python main.py PlayerName
 ```
+
+### Windows / live-test machine
+
+There's no dev environment on Windows - just a cold `git pull` of `main`.
+One script handles the rest:
+
+```powershell
+git pull
+.\setup.ps1
+```
+
+`setup.ps1` creates `.venv`, installs dependencies, creates `.env` from
+`.env.example` if it doesn't exist yet, and runs `doctor.py` at the end to
+confirm everything (Python version, dependencies, `.env`, data directories,
+and a live PUBG API heartbeat) is actually working before you run
+`main.py`.
+
+If PowerShell blocks the script from running (`cannot be loaded because
+running scripts is disabled on this system`), run it with:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File setup.ps1
+```
+
+Re-run `python doctor.py` any time to re-check the environment without
+redoing setup.
 
 ## How It Works
 
@@ -66,6 +93,8 @@ main.py
 
 ```
 ├── main.py                 # CLI entry point
+├── doctor.py                # Environment health check (Python, deps, .env, API heartbeat)
+├── setup.ps1                # One-click Windows setup (venv, deps, .env, doctor)
 ├── api/                     # PUBG API client: player stats, telemetry, player index, rate limiter
 ├── utils/                   # Display formatting + I/O helpers
 ├── tests/                   # Unit tests
@@ -74,6 +103,7 @@ main.py
 ├── match-telemetry/          # Cached raw telemetry JSON (local only, gitignored)
 ├── playerstats/              # Cached player stat JSON (local only, gitignored)
 ├── player-index.json         # Known player lookup (local only, gitignored)
+├── .env.example              # Template for local .env (PUBG_API_KEY, tunables)
 └── requirements.txt
 ```
 

--- a/doctor.py
+++ b/doctor.py
@@ -1,0 +1,125 @@
+# ==============================
+# doctor.py - environment health check
+# ==============================
+# Run after setup (or any time) to confirm the local environment is ready
+# to run main.py: python doctor.py
+import asyncio
+import importlib.util
+import os
+import sys
+
+import aiohttp
+from dotenv import dotenv_values, load_dotenv
+
+REQUIRED_PACKAGES = ["dotenv", "aiohttp"]
+REQUIRED_DIRS = ["playerstats", "match-telemetry"]
+STATUS_URL = "https://api.pubg.com/status"
+
+
+def _read_expected_python_version(version_file):
+    try:
+        with open(version_file) as f:
+            return f.read().strip()
+    except FileNotFoundError:
+        return None
+
+
+def check_python_version(version_file=".python-version"):
+    expected = _read_expected_python_version(version_file)
+    actual = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+    if expected is None:
+        return True, f"Python {actual} (no .python-version to compare against)"
+    if actual == expected:
+        return True, f"Python {actual}"
+    return False, f"Python {actual}, expected {expected} (see .python-version)"
+
+
+def check_virtual_env():
+    in_venv = sys.prefix != getattr(sys, "base_prefix", sys.prefix)
+    if in_venv:
+        return True, f"Active venv: {sys.prefix}"
+    return False, "No virtual environment active - run setup.ps1 or `python -m venv .venv` first"
+
+
+def check_packages(packages=REQUIRED_PACKAGES):
+    missing = [pkg for pkg in packages if importlib.util.find_spec(pkg) is None]
+    if missing:
+        return False, f"Missing packages: {', '.join(missing)} - run `pip install -r requirements.txt`"
+    return True, f"All required packages installed ({', '.join(packages)})"
+
+
+def check_env_file(env_path=".env"):
+    if not os.path.exists(env_path):
+        return False, f"{env_path} not found - copy .env.example to {env_path} and add your PUBG API key"
+    if not dotenv_values(env_path).get("PUBG_API_KEY"):
+        return False, "PUBG_API_KEY not set in .env"
+    return True, "PUBG_API_KEY is set"
+
+
+def check_data_dirs(dirs=REQUIRED_DIRS, base_dir="."):
+    created = []
+    for directory in dirs:
+        path = os.path.join(base_dir, directory)
+        if not os.path.isdir(path):
+            os.makedirs(path, exist_ok=True)
+            created.append(directory)
+    if created:
+        return True, f"Created missing directories: {', '.join(created)}"
+    return True, f"All data directories present ({', '.join(dirs)})"
+
+
+async def _ping_pubg_api():
+    api_key = os.getenv("PUBG_API_KEY")
+    headers = {"Accept": "application/vnd.api+json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    async with aiohttp.ClientSession() as session:
+        async with session.get(STATUS_URL, headers=headers, timeout=aiohttp.ClientTimeout(total=10)) as resp:
+            return resp.status
+
+
+def check_api_heartbeat():
+    try:
+        status = asyncio.run(_ping_pubg_api())
+    except Exception as e:
+        return False, f"Could not reach PUBG API: {e}"
+    if status == 200:
+        return True, "PUBG API reachable (status 200)"
+    return False, f"PUBG API returned status {status}"
+
+
+CHECKS = [
+    ("Python version", check_python_version),
+    ("Virtual environment", check_virtual_env),
+    ("Dependencies", check_packages),
+    ("Environment file", check_env_file),
+    ("Data directories", check_data_dirs),
+    ("PUBG API heartbeat", check_api_heartbeat),
+]
+
+
+def main():
+    load_dotenv()
+
+    print("=============================")
+    print("🩺 Environment Doctor")
+    print("=============================")
+
+    all_ok = True
+    for label, check in CHECKS:
+        ok, message = check()
+        icon = "✅" if ok else "❌"
+        print(f"{icon} {label:<22}: {message}")
+        all_ok = all_ok and ok
+
+    print()
+    if all_ok:
+        print("All checks passed - ready to run: python main.py <playername>")
+        sys.exit(0)
+    else:
+        print("One or more checks failed - fix the issues above before running main.py")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.ps1
+++ b/setup.ps1
@@ -1,0 +1,67 @@
+# ==============================
+# setup.ps1 - one-click Windows setup
+# ==============================
+# Run from the project root after `git pull`:
+#   .\setup.ps1
+# Creates the virtual environment, installs dependencies, sets up .env if
+# missing, and runs doctor.py to confirm everything is healthy.
+
+$ErrorActionPreference = "Stop"
+
+function Write-Step($message) {
+    Write-Host ""
+    Write-Host "==> $message" -ForegroundColor Cyan
+}
+
+$expectedVersion = (Get-Content ".python-version" -ErrorAction SilentlyContinue)
+$expectedMajorMinor = ($expectedVersion -split '\.')[0..1] -join '.'
+
+Write-Step "Locating Python $expectedVersion"
+$pythonCmd = $null
+foreach ($candidate in @("py -$expectedMajorMinor", "python")) {
+    $parts = $candidate.Split(" ")
+    if (Get-Command $parts[0] -ErrorAction SilentlyContinue) {
+        $pythonCmd = $candidate
+        break
+    }
+}
+if (-not $pythonCmd) {
+    Write-Host "No Python interpreter found on PATH. Install Python $expectedVersion first." -ForegroundColor Red
+    exit 1
+}
+Write-Host "Using: $pythonCmd"
+
+Write-Step "Creating virtual environment (.venv)"
+if (-not (Test-Path ".venv")) {
+    Invoke-Expression "$pythonCmd -m venv .venv"
+} else {
+    Write-Host ".venv already exists, skipping creation"
+}
+
+Write-Step "Activating virtual environment"
+. .\.venv\Scripts\Activate.ps1
+
+Write-Step "Installing dependencies"
+pip install -r requirements.txt
+
+Write-Step "Setting up .env"
+if (-not (Test-Path ".env")) {
+    Copy-Item ".env.example" ".env"
+    Write-Host ".env created from .env.example - add your PUBG_API_KEY before running main.py" -ForegroundColor Yellow
+} else {
+    Write-Host ".env already exists, skipping"
+}
+
+Write-Step "Running environment doctor"
+python doctor.py
+$doctorExitCode = $LASTEXITCODE
+
+if ($doctorExitCode -eq 0) {
+    Write-Host ""
+    Write-Host "Setup complete. Run: python main.py <playername>" -ForegroundColor Green
+} else {
+    Write-Host ""
+    Write-Host "Setup finished but the doctor found issues - see above." -ForegroundColor Yellow
+}
+
+exit $doctorExitCode

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,151 @@
+##########
+# Unit Test for Environment Doctor
+# from root of project: `python -m unittest discover tests`
+##########
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+import doctor
+
+
+class TestCheckPythonVersion(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+
+    def _write_version_file(self, version):
+        path = os.path.join(self.tmpdir.name, ".python-version")
+        with open(path, "w") as f:
+            f.write(version)
+        return path
+
+    def test_passes_when_version_matches(self):
+        actual = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+        path = self._write_version_file(actual)
+
+        ok, message = doctor.check_python_version(version_file=path)
+
+        self.assertTrue(ok)
+
+    def test_fails_when_version_mismatches(self):
+        path = self._write_version_file("99.99.99")
+
+        ok, message = doctor.check_python_version(version_file=path)
+
+        self.assertFalse(ok)
+        self.assertIn("99.99.99", message)
+
+    def test_passes_when_no_version_file_present(self):
+        ok, message = doctor.check_python_version(version_file=os.path.join(self.tmpdir.name, "missing"))
+
+        self.assertTrue(ok)
+
+
+class TestCheckPackages(unittest.TestCase):
+
+    def test_passes_when_all_installed(self):
+        ok, message = doctor.check_packages(packages=["os", "sys"])
+
+        self.assertTrue(ok)
+
+    def test_fails_and_lists_missing_packages(self):
+        ok, message = doctor.check_packages(packages=["os", "definitely_not_a_real_package"])
+
+        self.assertFalse(ok)
+        self.assertIn("definitely_not_a_real_package", message)
+
+
+class TestCheckEnvFile(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+
+    def test_fails_when_file_missing(self):
+        ok, message = doctor.check_env_file(env_path=os.path.join(self.tmpdir.name, ".env"))
+
+        self.assertFalse(ok)
+
+    def test_fails_when_key_missing(self):
+        path = os.path.join(self.tmpdir.name, ".env")
+        with open(path, "w") as f:
+            f.write("SOME_OTHER_VAR=value\n")
+
+        ok, message = doctor.check_env_file(env_path=path)
+
+        self.assertFalse(ok)
+        self.assertIn("PUBG_API_KEY", message)
+
+    def test_fails_when_key_present_but_empty(self):
+        path = os.path.join(self.tmpdir.name, ".env")
+        with open(path, "w") as f:
+            f.write("PUBG_API_KEY=\n")
+
+        ok, message = doctor.check_env_file(env_path=path)
+
+        self.assertFalse(ok)
+
+    def test_passes_when_key_set(self):
+        path = os.path.join(self.tmpdir.name, ".env")
+        with open(path, "w") as f:
+            f.write("PUBG_API_KEY=abc123\n")
+
+        ok, message = doctor.check_env_file(env_path=path)
+
+        self.assertTrue(ok)
+
+
+class TestCheckDataDirs(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+
+    def test_creates_missing_directories(self):
+        ok, message = doctor.check_data_dirs(dirs=["foo", "bar"], base_dir=self.tmpdir.name)
+
+        self.assertTrue(ok)
+        self.assertTrue(os.path.isdir(os.path.join(self.tmpdir.name, "foo")))
+        self.assertTrue(os.path.isdir(os.path.join(self.tmpdir.name, "bar")))
+        self.assertIn("foo", message)
+
+    def test_reports_no_creation_when_already_present(self):
+        os.makedirs(os.path.join(self.tmpdir.name, "foo"))
+
+        ok, message = doctor.check_data_dirs(dirs=["foo"], base_dir=self.tmpdir.name)
+
+        self.assertTrue(ok)
+        self.assertNotIn("Created", message)
+
+
+class TestCheckApiHeartbeat(unittest.TestCase):
+    """Mocks the network boundary - never calls the real PUBG API in tests."""
+
+    def test_passes_on_status_200(self):
+        with mock.patch("doctor._ping_pubg_api", return_value=200):
+            ok, message = doctor.check_api_heartbeat()
+
+        self.assertTrue(ok)
+
+    def test_fails_on_non_200_status(self):
+        with mock.patch("doctor._ping_pubg_api", return_value=503):
+            ok, message = doctor.check_api_heartbeat()
+
+        self.assertFalse(ok)
+        self.assertIn("503", message)
+
+    def test_fails_when_request_raises(self):
+        with mock.patch("doctor._ping_pubg_api", side_effect=ConnectionError("no route to host")):
+            ok, message = doctor.check_api_heartbeat()
+
+        self.assertFalse(ok)
+        self.assertIn("no route to host", message)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- `doctor.py` - checks Python version, virtual env, dependencies, `.env`/API key, data directories, and does a live PUBG API heartbeat; clear pass/fail per check, non-zero exit on failure.
- `setup.ps1` - one-click Windows setup: creates `.venv`, installs dependencies, creates `.env` from `.env.example` if missing, runs `doctor.py` at the end.
- `.env.example` - template for the four env vars the app actually reads (`PUBG_API_KEY`, `PUBG_RATE_LIMIT_PER_MINUTE`, `TELEMETRY_CONCURRENCY`, `TELEMETRY_MAX_NEW_PER_RUN`).
- README updated with a Windows quick-start section, including the PowerShell execution-policy workaround.

## Test plan
- [x] `python -m unittest discover tests` - all 67 tests pass, including 16 new `doctor.py` unit tests (version match/mismatch, missing packages, `.env` present/missing/empty key, directory creation, API heartbeat mocked at the network boundary per the existing testing standard)
- [x] Manual smoke test on macOS: ran `python doctor.py` against the real `.env` and real PUBG API - all six checks passed, including a genuine 200 from the live heartbeat; also verified the failure path with `.env` temporarily removed
- [ ] `setup.ps1` itself is **not yet verified on Windows** - no PowerShell available in the dev environment to test it directly. Needs a real run on the Windows machine before being treated as fully proven; flagging per this project's macOS-dev/Windows-live-test split.