### PR TITLE
Mode 1: Pre-Game Round-Start Intel

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,14 +92,17 @@ main.py
  │     ├─ time-to-first-contact tempo bucket       → utils/tempo_signal.py
  │     ├─ median kill-distance range bucket        → utils/range_signal.py
  │     └─ weapon-class preference / Wildcard       → utils/weapon_signature.py
+ ├──▶ Headline Number: confidence-gated "so-what"  → utils/headline_number.py
  ├──▶ Last match brief for this player             → utils/last_match_brief.py
  └──▶ Bot detection for the most recent match       → utils/bot_detection.py
 ```
 
-Archetype Tag scopes each player to their own recent matches (see
-`utils/match_scope.py`) - a widening 30-90 day recency window, capped at a
-configurable match count - rather than scanning every cached match, since
-telemetry caching is shared across all players ever looked up.
+Archetype Tag and the Headline Number both scope each player to their own
+recent matches (see `utils/match_scope.py`) - a widening 30-90 day recency
+window, capped at a configurable match count - rather than scanning every
+cached match, since telemetry caching is shared across all players ever
+looked up. `main.py` resolves this scoped match set once per run and
+reuses it across both, rather than each rescanning the cache separately.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ python doctor.py
 python main.py PlayerName
 ```
 
+To profile a whole squad at once (2+ players, you first) instead:
+
+```bash
+python squad.py YourName Teammate1 Teammate2
+```
+
 ### Windows / live-test machine
 
 There's no dev environment on Windows - just a cold `git pull` of `main`.
@@ -104,10 +110,20 @@ cached match, since telemetry caching is shared across all players ever
 looked up. `main.py` resolves this scoped match set once per run and
 reuses it across both, rather than each rescanning the cache separately.
 
+`squad.py` is a separate multi-player entry point (`main.py`'s
+single-player flow is untouched) for profiling a whole squad in one run:
+`utils/squad_read.py` + `utils/squad_roster.py` combine each teammate's
+Archetype Tag into a synergy/coverage read, bolstered with a data-backed
+"who opens first" line when the pattern is consistent enough. Player-stats
+fetches run concurrently across the squad, and telemetry is fetched once
+per unique match across the whole squad rather than once per player, so a
+match two teammates shared only gets pulled once.
+
 ## Project Structure
 
 ```
-├── main.py                 # CLI entry point
+├── main.py                 # CLI entry point (single player)
+├── squad.py                 # CLI entry point (2+ players at once)
 ├── doctor.py                # Environment health check (Python, deps, .env, API heartbeat)
 ├── setup.ps1                # One-click Windows setup (venv, deps, .env, doctor)
 ├── api/                     # PUBG API client: player stats, telemetry, player index, rate limiter

--- a/api/player_stats.py
+++ b/api/player_stats.py
@@ -5,6 +5,7 @@ import os
 from dotenv import load_dotenv
 from api.player_index import update_player_index
 from api.rate_limiter import player_api_queue
+from utils.io_helpers import save_json
 
 load_dotenv()
 
@@ -29,3 +30,20 @@ async def fetch_player_stats(playername):
     stats_url = f"{BASE_URL}/players/{player_id}/seasons/lifetime"
     stats_data = await player_api_queue.request("GET", stats_url, headers=HEADERS)
     return stats_data, player_id
+
+
+async def fetch_player_and_match_ids(playername):
+    """Resolve a player's account ID, save their lifetime stats, and
+    return their known match ID list - the shared first step needed by
+    both the single-player CLI (main.py) and multi-player squad lookups
+    (squad.py), so both stay behaviorally identical for this step.
+    """
+    data, player_id = await fetch_player_stats(playername)
+    save_json(data, f"playerstats/{playername}.json")
+
+    match_ids = []
+    for key, relationship in data["data"]["relationships"].items():
+        if key.startswith("matches"):
+            match_ids.extend([entry["id"] for entry in relationship.get("data", [])])
+
+    return player_id, match_ids

--- a/docs/architecture/data-flow.html
+++ b/docs/architecture/data-flow.html
@@ -7,15 +7,15 @@
     --ink-dim: #58635e;
     --line: #d4d9d3;
     --accent: #2f7d70;
-    --accent-ink: #ffffff;
+    --accent-soft: #dff0ec;
+    --api: #3d6b86;
+    --api-soft: #e1ebf1;
     --fresh: #2f6fa8;
-    --fresh-soft: #e4edf6;
+    --fresh-soft: #dce9f6;
     --immutable: #a9782c;
-    --immutable-soft: #f6ecd7;
+    --immutable-soft: #f5ead0;
     --merge: #6f5aa3;
-    --merge-soft: #ece7f6;
-    --derived: #58635e;
-    --code-bg: #e9ece7;
+    --merge-soft: #e9e2f5;
     --shadow: 0 1px 2px rgba(20, 30, 25, 0.06), 0 8px 24px rgba(20, 30, 25, 0.05);
   }
 
@@ -26,15 +26,15 @@
     --ink-dim: #93a19a;
     --line: #2a322c;
     --accent: #5fbfae;
-    --accent-ink: #0b1512;
+    --accent-soft: #17332c;
+    --api: #8fc0dd;
+    --api-soft: #182a34;
     --fresh: #7fb3e0;
-    --fresh-soft: #1c2a36;
+    --fresh-soft: #17293a;
     --immutable: #e0b262;
-    --immutable-soft: #332a17;
+    --immutable-soft: #332916;
     --merge: #b6a4e6;
     --merge-soft: #241f36;
-    --derived: #93a19a;
-    --code-bg: #1e2521;
     --shadow: 0 1px 2px rgba(0, 0, 0, 0.3), 0 12px 28px rgba(0, 0, 0, 0.35);
   }
 
@@ -46,20 +46,27 @@
       --ink-dim: #93a19a;
       --line: #2a322c;
       --accent: #5fbfae;
-      --accent-ink: #0b1512;
+      --accent-soft: #17332c;
+      --api: #8fc0dd;
+      --api-soft: #182a34;
       --fresh: #7fb3e0;
-      --fresh-soft: #1c2a36;
+      --fresh-soft: #17293a;
       --immutable: #e0b262;
-      --immutable-soft: #332a17;
+      --immutable-soft: #332916;
       --merge: #b6a4e6;
       --merge-soft: #241f36;
-      --derived: #93a19a;
-      --code-bg: #1e2521;
       --shadow: 0 1px 2px rgba(0, 0, 0, 0.3), 0 12px 28px rgba(0, 0, 0, 0.35);
     }
   }
 
   * { box-sizing: border-box; }
+
+  svg { display: block; overflow: visible; }
+  svg.icon { flex: none; width: 16px; height: 16px; }
+  svg.icon polygon, svg.icon rect, svg.icon circle, svg.icon line {
+    fill: none; stroke: currentColor; stroke-width: 1.6; stroke-linejoin: round; stroke-linecap: round;
+  }
+  svg.icon polygon { fill: currentColor; stroke: none; }
 
   body {
     margin: 0;
@@ -70,9 +77,7 @@
     -webkit-font-smoothing: antialiased;
   }
 
-  .mono {
-    font-family: ui-monospace, "SF Mono", "Cascadia Code", "Roboto Mono", Menlo, Consolas, monospace;
-  }
+  .mono { font-family: ui-monospace, "SF Mono", "Cascadia Code", "Roboto Mono", Menlo, Consolas, monospace; }
 
   header {
     padding: 2.25rem clamp(1.25rem, 4vw, 3rem) 1.25rem;
@@ -99,12 +104,7 @@
     letter-spacing: -0.01em;
   }
 
-  header p {
-    max-width: 62ch;
-    color: var(--ink-dim);
-    margin: 0;
-    font-size: 0.96rem;
-  }
+  header p { max-width: 62ch; color: var(--ink-dim); margin: 0; font-size: 0.96rem; }
 
   nav.tabs {
     max-width: 1180px;
@@ -116,13 +116,12 @@
     position: sticky;
     top: 0;
     background: var(--bg);
-    z-index: 5;
+    z-index: 10;
   }
 
   .tab-btn {
     font-family: ui-monospace, "SF Mono", "Cascadia Code", "Roboto Mono", Menlo, Consolas, monospace;
     font-size: 0.82rem;
-    letter-spacing: 0.02em;
     background: transparent;
     border: none;
     color: var(--ink-dim);
@@ -132,25 +131,11 @@
     margin-bottom: -1px;
     transition: color 0.15s ease, border-color 0.15s ease;
   }
-
   .tab-btn:hover { color: var(--ink); }
+  .tab-btn.active { color: var(--accent); border-bottom-color: var(--accent); }
+  .tab-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
-  .tab-btn.active {
-    color: var(--accent);
-    border-bottom-color: var(--accent);
-  }
-
-  .tab-btn:focus-visible {
-    outline: 2px solid var(--accent);
-    outline-offset: 2px;
-  }
-
-  main {
-    max-width: 1180px;
-    margin: 0 auto;
-    padding: 1.75rem clamp(1.25rem, 4vw, 3rem) 4rem;
-  }
-
+  main { max-width: 1180px; margin: 0 auto; padding: 1.75rem clamp(1.25rem, 4vw, 3rem) 4rem; }
   .panel { display: none; }
   .panel.active { display: block; }
 
@@ -160,249 +145,448 @@
     font-weight: 600;
     margin: 0 0 0.35rem;
   }
+  .panel > p.lede { color: var(--ink-dim); max-width: 68ch; margin: 0 0 1.1rem; font-size: 0.95rem; }
 
-  .panel > p.lede {
-    color: var(--ink-dim);
-    max-width: 68ch;
-    margin: 0 0 1.25rem;
-    font-size: 0.95rem;
-  }
+  /* ---------- shared legend chip ---------- */
+  .legend { display: flex; flex-wrap: wrap; gap: 0.5rem 1.1rem; margin: 0 0 1.25rem;
+    padding: 0.75rem 1rem; background: var(--bg-raised); border: 1px solid var(--line);
+    border-radius: 8px; box-shadow: var(--shadow); }
+  .legend-item { display: flex; align-items: center; gap: 0.5rem; font-size: 0.78rem; color: var(--ink-dim); }
+  .legend-item svg.icon { color: var(--ink); }
+  .swatch { width: 0.65rem; height: 0.65rem; border-radius: 3px; flex: none; border: 1.5px solid; }
 
-  .legend {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem 1.1rem;
-    margin: 0 0 1.25rem;
-    padding: 0.85rem 1rem;
-    background: var(--bg-raised);
-    border: 1px solid var(--line);
-    border-radius: 8px;
-    box-shadow: var(--shadow);
-  }
+  /* ================= DIAGRAM 1 — pipeline ================= */
+  .pipeline-scroll { overflow-x: auto; padding-bottom: 0.5rem; }
+  .pipeline { min-width: 900px; display: flex; flex-direction: column; }
 
-  .legend-item {
-    display: flex;
-    align-items: center;
-    gap: 0.45rem;
-    font-size: 0.8rem;
-    color: var(--ink-dim);
-  }
+  .stage { background: var(--bg-raised); border: 1px solid var(--line); border-radius: 12px;
+    box-shadow: var(--shadow); padding: 1rem 1.1rem 1.15rem; }
+  .stage-head { display: flex; align-items: baseline; gap: 0.6rem; margin-bottom: 0.75rem; }
+  .stage-num { font-family: ui-monospace, monospace; font-size: 0.72rem; color: var(--bg-raised);
+    background: var(--ink); border-radius: 4px; padding: 0.12rem 0.4rem; }
+  .stage-title { font-family: ui-monospace, monospace; font-size: 0.86rem; font-weight: 600; }
+  .stage-desc { font-size: 0.78rem; color: var(--ink-dim); margin-left: auto; text-align: right; max-width: 42ch; }
 
-  .swatch {
-    width: 0.7rem;
-    height: 0.7rem;
-    border-radius: 2px;
-    flex: none;
-  }
+  .stage-row { display: flex; align-items: stretch; gap: 0; }
 
-  .diagram-wrap {
-    background: var(--bg-raised);
-    border: 1px solid var(--line);
-    border-radius: 10px;
-    box-shadow: var(--shadow);
-    padding: 1.25rem;
-    overflow-x: auto;
-  }
+  .pconn { flex: none; width: 30px; display: flex; align-items: center; justify-content: center; color: var(--ink-dim); }
 
-  .diagram-wrap pre.mermaid {
-    margin: 0;
-    min-width: 720px;
-  }
+  .pnode { flex: none; width: 168px; border-radius: 10px; border: 1.5px solid var(--line);
+    background: var(--bg); padding: 0.55rem 0.6rem 0.6rem; display: flex; flex-direction: column; gap: 0.3rem; }
+  .pnode-type { display: flex; align-items: center; gap: 0.35rem; font-family: ui-monospace, monospace;
+    font-size: 0.6rem; letter-spacing: 0.06em; text-transform: uppercase; }
+  .pnode-title { font-size: 0.78rem; font-weight: 600; color: var(--ink); line-height: 1.25; }
+  .pnode-sub { font-size: 0.68rem; color: var(--ink-dim); line-height: 1.3; }
 
-  .notes {
-    margin-top: 1.5rem;
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-    gap: 0.9rem;
-  }
+  .pnode.t-api { border-color: var(--api); background: var(--api-soft); }
+  .pnode.t-api .pnode-type { color: var(--api); }
+  .pnode.t-fresh { border-color: var(--fresh); background: var(--fresh-soft); }
+  .pnode.t-fresh .pnode-type { color: var(--fresh); }
+  .pnode.t-immutable { border-color: var(--immutable); background: var(--immutable-soft); }
+  .pnode.t-immutable .pnode-type { color: var(--immutable); }
+  .pnode.t-merge { border-color: var(--merge); background: var(--merge-soft); }
+  .pnode.t-merge .pnode-type { color: var(--merge); }
+  .pnode.t-compute { border-color: var(--accent); background: var(--accent-soft); }
+  .pnode.t-compute .pnode-type { color: var(--accent); }
+  .pnode.t-neutral { border-color: var(--line); background: var(--bg-raised); }
+  .pnode.t-neutral .pnode-type { color: var(--ink-dim); }
 
-  .note {
-    background: var(--bg-raised);
-    border: 1px solid var(--line);
-    border-left: 3px solid var(--accent-line, var(--accent));
-    border-radius: 6px;
-    padding: 0.85rem 1rem;
-    font-size: 0.85rem;
-    color: var(--ink-dim);
-  }
+  .stage-drop { display: flex; align-items: center; gap: 0.6rem; padding: 0.5rem 0 0.5rem 1.4rem; color: var(--ink-dim); }
+  .stage-drop .line { width: 1.5px; height: 22px; background: var(--line); }
+  .stage-drop .note { font-size: 0.72rem; font-style: normal; }
 
-  .note strong {
-    display: block;
-    color: var(--ink);
-    font-size: 0.82rem;
-    margin-bottom: 0.25rem;
-    font-family: ui-monospace, "SF Mono", "Cascadia Code", "Roboto Mono", Menlo, Consolas, monospace;
-  }
+  /* branch fork inside stage 2 */
+  .branch { display: flex; align-items: center; gap: 0.5rem; }
+  .diamond { width: 92px; height: 92px; flex: none; transform: rotate(45deg); border-radius: 10px;
+    border: 1.5px solid var(--immutable); background: var(--immutable-soft); display: flex;
+    align-items: center; justify-content: center; }
+  .diamond-inner { transform: rotate(-45deg); text-align: center; font-family: ui-monospace, monospace;
+    font-size: 0.68rem; color: var(--immutable); line-height: 1.2; padding: 0 0.3rem; }
 
-  .note code {
-    font-family: ui-monospace, "SF Mono", "Cascadia Code", "Roboto Mono", Menlo, Consolas, monospace;
-    background: var(--code-bg);
-    padding: 0.1rem 0.35rem;
-    border-radius: 4px;
-    font-size: 0.82em;
-  }
+  .lanes { position: relative; padding-left: 1.5rem; display: flex; flex-direction: column; gap: 0.8rem; margin-left: 0.4rem; }
+  .lanes::before { content: ""; position: absolute; left: 0; top: 12%; bottom: 12%; border-left: 2px solid var(--immutable); }
+  .lane { position: relative; display: flex; align-items: center; gap: 0.5rem; }
+  .lane::before { content: ""; position: absolute; left: -1.5rem; top: 50%; width: 1.5rem; border-top: 2px solid var(--immutable); }
+  .lane-tag { font-family: ui-monospace, monospace; font-size: 0.62rem; letter-spacing: 0.06em; color: var(--immutable);
+    background: var(--immutable-soft); border: 1px solid var(--immutable); border-radius: 4px; padding: 0.15rem 0.35rem; flex: none; }
 
+  /* ================= DIAGRAM 2 — relational ================= */
+  .rel-scroll { overflow-x: auto; }
+  .relational-canvas { position: relative; width: 960px; height: 760px; }
+  .relational-canvas svg.edges { position: absolute; inset: 0; width: 960px; height: 760px; }
+  .relational-canvas svg.edges path { fill: none; stroke-width: 2; }
+  .edge-label { position: absolute; transform: translate(-50%, -50%); background: var(--bg);
+    border: 1px solid var(--line); border-radius: 5px; padding: 0.15rem 0.4rem; font-size: 0.66rem;
+    color: var(--ink-dim); max-width: 190px; text-align: center; line-height: 1.25; font-family: ui-sans-serif, sans-serif; }
+
+  .rnode { position: absolute; border-radius: 12px; border: 1.5px solid var(--line); background: var(--bg-raised);
+    box-shadow: var(--shadow); padding: 0.7rem 0.85rem; display: flex; flex-direction: column; gap: 0.35rem; z-index: 2; }
+  .rnode-kind { display: flex; align-items: center; gap: 0.4rem; font-family: ui-monospace, monospace;
+    font-size: 0.62rem; letter-spacing: 0.06em; text-transform: uppercase; }
+  .rnode-title { font-family: ui-monospace, monospace; font-size: 0.83rem; font-weight: 600; color: var(--ink); }
+  .rnode-note { font-size: 0.72rem; color: var(--ink-dim); line-height: 1.3; }
+
+  .rnode.k-api { border-color: var(--api); }
+  .rnode.k-api .rnode-kind { color: var(--api); }
+  .rnode.k-fresh { border-color: var(--fresh); background: var(--fresh-soft); }
+  .rnode.k-fresh .rnode-kind { color: var(--fresh); }
+  .rnode.k-immutable { border-color: var(--immutable); background: var(--immutable-soft); }
+  .rnode.k-immutable .rnode-kind { color: var(--immutable); }
+  .rnode.k-merge { border-color: var(--merge); background: var(--merge-soft); }
+  .rnode.k-merge .rnode-kind { color: var(--merge); }
+
+  .rstack { position: absolute; border-radius: 12px; border: 1.5px solid var(--immutable); opacity: 0.35; z-index: 1; }
+
+  .col-label { position: absolute; top: -28px; font-family: ui-monospace, monospace; font-size: 0.68rem;
+    letter-spacing: 0.1em; text-transform: uppercase; color: var(--ink-dim); }
+
+  .notes { margin-top: 1.5rem; display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 0.9rem; }
+  .note { background: var(--bg-raised); border: 1px solid var(--line); border-left: 3px solid var(--accent);
+    border-radius: 6px; padding: 0.8rem 0.95rem; font-size: 0.83rem; color: var(--ink-dim); }
+  .note strong { display: block; color: var(--ink); font-size: 0.8rem; margin-bottom: 0.25rem; font-family: ui-monospace, monospace; }
+  .note code { font-family: ui-monospace, monospace; background: var(--immutable-soft); padding: 0.1rem 0.35rem; border-radius: 4px; font-size: 0.82em; }
   .note.fresh { border-left-color: var(--fresh); }
   .note.immutable { border-left-color: var(--immutable); }
   .note.merge { border-left-color: var(--merge); }
 
-  footer {
-    max-width: 1180px;
-    margin: 0 auto;
-    padding: 0 clamp(1.25rem, 4vw, 3rem) 3rem;
-    color: var(--ink-dim);
-    font-size: 0.78rem;
-  }
+  footer { max-width: 1180px; margin: 0 auto; padding: 0 clamp(1.25rem, 4vw, 3rem) 3rem; color: var(--ink-dim); font-size: 0.78rem; }
+  footer code { font-family: ui-monospace, monospace; }
 
-  footer code { font-family: ui-monospace, "SF Mono", "Cascadia Code", "Roboto Mono", Menlo, Consolas, monospace; }
-
-  @media (prefers-reduced-motion: reduce) {
-    * { transition: none !important; }
-  }
+  @media (prefers-reduced-motion: reduce) { * { transition: none !important; } }
 </style>
+
+<svg style="display:none" aria-hidden="true">
+  <defs>
+    <symbol id="i-api" viewBox="0 0 24 24"><polygon points="3,7 14,7 14,3 21,12 14,21 14,17 3,17 3,13 12,13 12,11 3,11"/></symbol>
+    <symbol id="i-write" viewBox="0 0 24 24"><rect x="4" y="3" width="16" height="18" rx="1.5"/><polygon points="8,10 16,10 12,16"/><line x1="12" y1="6" x2="12" y2="12"/></symbol>
+    <symbol id="i-read" viewBox="0 0 24 24"><rect x="4" y="3" width="16" height="18" rx="1.5"/><polygon points="8,14 16,14 12,8"/><line x1="12" y1="18" x2="12" y2="12"/></symbol>
+    <symbol id="i-merge" viewBox="0 0 24 24"><rect x="4" y="3" width="16" height="18" rx="1.5"/><circle cx="12" cy="12" r="3"/><circle cx="12" cy="12" r="6"/></symbol>
+    <symbol id="i-compute" viewBox="0 0 24 24"><polygon points="12,2 22,12 12,22 2,12"/><circle cx="12" cy="12" r="2.4" fill="var(--bg)" stroke="none"/></symbol>
+    <symbol id="i-display" viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="12" rx="1.5"/><line x1="8" y1="20" x2="16" y2="20"/><line x1="12" y1="16" x2="12" y2="20"/></symbol>
+    <symbol id="i-shared" viewBox="0 0 24 24"><rect x="2" y="8" width="13" height="13" rx="1.5"/><rect x="6" y="4" width="13" height="13" rx="1.5"/><rect x="9" y="1" width="13" height="12" rx="1.5"/></symbol>
+    <symbol id="i-arrow-r" viewBox="0 0 20 20"><polygon points="4,3 4,17 17,10"/></symbol>
+    <symbol id="i-arrow-d" viewBox="0 0 20 20"><polygon points="3,4 17,4 10,17"/></symbol>
+  </defs>
+</svg>
 
 <header>
   <p class="eyebrow">pubg-teammate-analysis / local data map</p>
   <h1>What a single run reads, writes, and reuses</h1>
-  <p>Two views of the same system: which local files each API call feeds (or gets fed by), and the actual execution order inside a <code class="mono">python main.py &lt;playername&gt;</code> run.</p>
+  <p>Two hand-laid-out diagrams of the same system: the actual step-by-step pipeline inside <code class="mono">python main.py &lt;playername&gt;</code>, and how the API calls and local files connect to and reuse one another.</p>
 </header>
 
 <nav class="tabs">
-  <button class="tab-btn active" data-tab="relationships">Relationships</button>
-  <button class="tab-btn" data-tab="sequence">Execution order</button>
+  <button class="tab-btn active" data-tab="pipeline">Data flow (execution order)</button>
+  <button class="tab-btn" data-tab="relational">Relational view (files ↔ API)</button>
 </nav>
 
 <main>
-  <section class="panel active" id="relationships">
-    <h2>API calls &rarr; local files</h2>
-    <p class="lede">Nodes are either a live PUBG API call or a file this project writes. Edges show what produces or reads what. Color marks how each file behaves across repeated runs &mdash; that behavior is the whole reason the caching layer exists.</p>
+  <section class="panel active" id="pipeline">
+    <h2>main.py — pipeline, in order</h2>
+    <p class="lede">Four stages, left to right within a stage, top to bottom across stages. The only branch in the whole run is the telemetry cache check — everything else is a straight line.</p>
 
     <div class="legend">
-      <div class="legend-item"><span class="swatch" style="background:var(--fresh)"></span>re-fetched every run (overwritten)</div>
-      <div class="legend-item"><span class="swatch" style="background:var(--immutable)"></span>write-once, immutable (cache-gated)</div>
-      <div class="legend-item"><span class="swatch" style="background:var(--merge)"></span>merge-updated index (never deleted from)</div>
-      <div class="legend-item"><span class="swatch" style="background:var(--ink-dim)"></span>API endpoint (response not persisted as-is)</div>
+      <div class="legend-item"><svg class="icon" style="color:var(--api)"><use href="#i-api"/></svg>API call</div>
+      <div class="legend-item"><svg class="icon" style="color:var(--fresh)"><use href="#i-write"/></svg>file write · overwritten every run</div>
+      <div class="legend-item"><svg class="icon" style="color:var(--immutable)"><use href="#i-write"/></svg>file write · write-once / immutable</div>
+      <div class="legend-item"><svg class="icon" style="color:var(--merge)"><use href="#i-merge"/></svg>file write · merge-updated index</div>
+      <div class="legend-item"><svg class="icon" style="color:var(--ink-dim)"><use href="#i-read"/></svg>file read</div>
+      <div class="legend-item"><svg class="icon" style="color:var(--accent)"><use href="#i-compute"/></svg>computation</div>
+      <div class="legend-item"><svg class="icon" style="color:var(--ink-dim)"><use href="#i-display"/></svg>terminal display</div>
     </div>
 
-    <div class="diagram-wrap">
-<pre class="mermaid">
-flowchart LR
-    A1["GET /players?filter[playerNames]=name<br/>resolve account ID"]
-    A2["GET /players/{id}/seasons/lifetime"]
-    A3["GET /matches/{match_id}<br/>metadata, for CDN asset URL"]
-    A4["GET {telemetry CDN URL}<br/>raw telemetry payload"]
+    <div class="pipeline-scroll">
+      <div class="pipeline">
 
-    PS["playerstats/{name}.json"]
-    PI["player-index.json"]
-    TM["match-telemetry/{match_id}-telemetry.json<br/>(shared across every player)"]
-    BI["bot-index.json"]
+        <!-- STAGE 1 -->
+        <div class="stage">
+          <div class="stage-head">
+            <span class="stage-num">01</span>
+            <span class="stage-title">Identity &amp; stats</span>
+            <span class="stage-desc">Resolve the player, refresh their lifetime stats unconditionally.</span>
+          </div>
+          <div class="stage-row">
+            <div class="pnode t-api">
+              <div class="pnode-type"><svg class="icon"><use href="#i-api"/></svg>API call</div>
+              <div class="pnode-title">GET /players?filter[playerNames]</div>
+              <div class="pnode-sub">resolve account ID</div>
+            </div>
+            <div class="pconn"><svg class="icon" style="width:18px;height:18px"><use href="#i-arrow-r"/></svg></div>
+            <div class="pnode t-merge">
+              <div class="pnode-type"><svg class="icon"><use href="#i-merge"/></svg>write · merge</div>
+              <div class="pnode-title">player-index.json</div>
+              <div class="pnode-sub">create or update entry</div>
+            </div>
+            <div class="pconn"><svg class="icon" style="width:18px;height:18px"><use href="#i-arrow-r"/></svg></div>
+            <div class="pnode t-api">
+              <div class="pnode-type"><svg class="icon"><use href="#i-api"/></svg>API call</div>
+              <div class="pnode-title">GET /seasons/lifetime</div>
+              <div class="pnode-sub">using player_id from step 1</div>
+            </div>
+            <div class="pconn"><svg class="icon" style="width:18px;height:18px"><use href="#i-arrow-r"/></svg></div>
+            <div class="pnode t-fresh">
+              <div class="pnode-type"><svg class="icon"><use href="#i-write"/></svg>write · overwrite</div>
+              <div class="pnode-title">playerstats/{name}.json</div>
+              <div class="pnode-sub">full response, every run</div>
+            </div>
+            <div class="pconn"><svg class="icon" style="width:18px;height:18px"><use href="#i-arrow-r"/></svg></div>
+            <div class="pnode t-neutral">
+              <div class="pnode-type"><svg class="icon"><use href="#i-display"/></svg>display</div>
+              <div class="pnode-title">stats table + match history</div>
+              <div class="pnode-sub">rendered to terminal</div>
+            </div>
+          </div>
+        </div>
 
-    A1 -->|player_id, response discarded| PI
-    A1 -->|player_id feeds next call| A2
-    A2 -->|full response saved| PS
-    PS -->|this player's match_ids, from relationships| TM
-    TM -.->|_is_cached? miss triggers| A3
-    A3 -->|asset URL, response discarded| A4
-    A4 -->|full payload saved| TM
-    TM -->|detect_bots on latest cached match| BI
+        <div class="stage-drop"><div class="line"></div><svg class="icon"><use href="#i-arrow-d"/></svg><span class="note">match_ids extracted from this player's own stats relationships</span></div>
 
-    class A1,A2,A3,A4 api
-    class PS fresh
-    class TM immutable
-    class PI,BI merge
+        <!-- STAGE 2 -->
+        <div class="stage">
+          <div class="stage-head">
+            <span class="stage-num">02</span>
+            <span class="stage-title">Telemetry ingestion</span>
+            <span class="stage-desc">The one branch in the run — gated by <code class="mono">_is_cached()</code> per match_id.</span>
+          </div>
+          <div class="branch">
+            <div class="pnode t-compute">
+              <div class="pnode-type"><svg class="icon"><use href="#i-compute"/></svg>compute</div>
+              <div class="pnode-title">extract match_ids</div>
+              <div class="pnode-sub">from playerstats relationships</div>
+            </div>
+            <div class="pconn"><svg class="icon" style="width:18px;height:18px"><use href="#i-arrow-r"/></svg></div>
+            <div class="diamond"><div class="diamond-inner">cached<br/>on disk?</div></div>
+            <div class="lanes">
+              <div class="lane">
+                <span class="lane-tag">HIT</span>
+                <div class="pnode t-neutral" style="width:150px">
+                  <div class="pnode-type" style="color:var(--ink-dim)"><svg class="icon"><use href="#i-read"/></svg>skip</div>
+                  <div class="pnode-title">already on disk</div>
+                  <div class="pnode-sub">no network call at all</div>
+                </div>
+              </div>
+              <div class="lane">
+                <span class="lane-tag">MISS</span>
+                <div class="pnode t-api">
+                  <div class="pnode-type"><svg class="icon"><use href="#i-api"/></svg>API call</div>
+                  <div class="pnode-title">GET /matches/{id}</div>
+                  <div class="pnode-sub">metadata, for asset URL</div>
+                </div>
+                <div class="pconn"><svg class="icon" style="width:18px;height:18px"><use href="#i-arrow-r"/></svg></div>
+                <div class="pnode t-api">
+                  <div class="pnode-type"><svg class="icon"><use href="#i-api"/></svg>API call</div>
+                  <div class="pnode-title">GET {telemetry CDN URL}</div>
+                  <div class="pnode-sub">raw telemetry payload</div>
+                </div>
+                <div class="pconn"><svg class="icon" style="width:18px;height:18px"><use href="#i-arrow-r"/></svg></div>
+                <div class="pnode t-immutable">
+                  <div class="pnode-type"><svg class="icon"><use href="#i-write"/></svg>write · once</div>
+                  <div class="pnode-title">{id}-telemetry.json</div>
+                  <div class="pnode-sub">never rewritten again</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
 
-    classDef api fill:#dfe3de,stroke:#58635e,color:#1b2321,stroke-width:1px;
-    classDef fresh fill:#dbe7f5,stroke:#2f6fa8,color:#122236;
-    classDef immutable fill:#f3e2bb,stroke:#a9782c,color:#3b2a0c;
-    classDef merge fill:#e4dcf4,stroke:#6f5aa3,color:#251c3d;
-</pre>
+        <div class="stage-drop"><div class="line"></div><svg class="icon"><use href="#i-arrow-d"/></svg><span class="note">cache now covers every match this player is known to have played</span></div>
+
+        <!-- STAGE 3 -->
+        <div class="stage">
+          <div class="stage-head">
+            <span class="stage-num">03</span>
+            <span class="stage-title">Analysis, from cache only</span>
+            <span class="stage-desc">No further network calls — everything below reads telemetry back off disk.</span>
+          </div>
+          <div class="stage-row">
+            <div class="pnode t-neutral">
+              <div class="pnode-type" style="color:var(--ink-dim)"><svg class="icon"><use href="#i-read"/></svg>read</div>
+              <div class="pnode-title">telemetry cache</div>
+              <div class="pnode-sub">this player's match_ids</div>
+            </div>
+            <div class="pconn"><svg class="icon" style="width:18px;height:18px"><use href="#i-arrow-r"/></svg></div>
+            <div class="pnode t-compute">
+              <div class="pnode-type"><svg class="icon"><use href="#i-compute"/></svg>compute</div>
+              <div class="pnode-title">combat stats</div>
+              <div class="pnode-sub">computed + rendered</div>
+            </div>
+            <div class="pconn"><svg class="icon" style="width:18px;height:18px"><use href="#i-arrow-r"/></svg></div>
+            <div class="pnode t-compute">
+              <div class="pnode-type"><svg class="icon"><use href="#i-compute"/></svg>compute</div>
+              <div class="pnode-title">select_scoped_match_ids</div>
+              <div class="pnode-sub">recency window / cap — computed once</div>
+            </div>
+            <div class="pconn"><svg class="icon" style="width:18px;height:18px"><use href="#i-arrow-r"/></svg></div>
+            <div class="pnode t-compute">
+              <div class="pnode-type"><svg class="icon"><use href="#i-compute"/></svg>compute</div>
+              <div class="pnode-title">Archetype Tag</div>
+              <div class="pnode-sub">tempo + range + weapon signature, rendered</div>
+            </div>
+            <div class="pconn"><svg class="icon" style="width:18px;height:18px"><use href="#i-arrow-r"/></svg></div>
+            <div class="pnode t-compute">
+              <div class="pnode-type"><svg class="icon"><use href="#i-compute"/></svg>compute</div>
+              <div class="pnode-title">Headline Number</div>
+              <div class="pnode-sub">same scoped set, rendered</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="stage-drop"><div class="line"></div><svg class="icon"><use href="#i-arrow-d"/></svg><span class="note">last-match + bot detection are independent lookups against the cache</span></div>
+
+        <!-- STAGE 4 -->
+        <div class="stage">
+          <div class="stage-head">
+            <span class="stage-num">04</span>
+            <span class="stage-title">Last match &amp; bot detection</span>
+            <span class="stage-desc">Two different scopes: this player's cache vs. the entire shared cache.</span>
+          </div>
+          <div class="stage-row">
+            <div class="pnode t-neutral">
+              <div class="pnode-type" style="color:var(--ink-dim)"><svg class="icon"><use href="#i-read"/></svg>read</div>
+              <div class="pnode-title">this player's latest match</div>
+              <div class="pnode-sub">player-scoped lookup</div>
+            </div>
+            <div class="pconn"><svg class="icon" style="width:18px;height:18px"><use href="#i-arrow-r"/></svg></div>
+            <div class="pnode t-compute">
+              <div class="pnode-type"><svg class="icon"><use href="#i-compute"/></svg>compute</div>
+              <div class="pnode-title">last-match brief</div>
+              <div class="pnode-sub">squad status at death, rendered</div>
+            </div>
+            <div class="pconn"><svg class="icon" style="width:18px;height:18px"><use href="#i-arrow-r"/></svg></div>
+            <div class="pnode t-neutral">
+              <div class="pnode-type" style="color:var(--ink-dim)"><svg class="icon"><use href="#i-read"/></svg>read</div>
+              <div class="pnode-title">latest match, whole cache</div>
+              <div class="pnode-sub">not player-scoped, by design</div>
+            </div>
+            <div class="pconn"><svg class="icon" style="width:18px;height:18px"><use href="#i-arrow-r"/></svg></div>
+            <div class="pnode t-compute">
+              <div class="pnode-type"><svg class="icon"><use href="#i-compute"/></svg>compute</div>
+              <div class="pnode-title">detect_bots</div>
+              <div class="pnode-sub">on that match's events</div>
+            </div>
+            <div class="pconn"><svg class="icon" style="width:18px;height:18px"><use href="#i-arrow-r"/></svg></div>
+            <div class="pnode t-merge">
+              <div class="pnode-type"><svg class="icon"><use href="#i-merge"/></svg>write · merge</div>
+              <div class="pnode-title">bot-index.json</div>
+              <div class="pnode-sub">records never deleted</div>
+            </div>
+            <div class="pconn"><svg class="icon" style="width:18px;height:18px"><use href="#i-arrow-r"/></svg></div>
+            <div class="pnode t-neutral">
+              <div class="pnode-type"><svg class="icon"><use href="#i-display"/></svg>display</div>
+              <div class="pnode-title">bot summary</div>
+              <div class="pnode-sub">rendered to terminal</div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </section>
+
+  <section class="panel" id="relational">
+    <h2>API calls ↔ local files</h2>
+    <p class="lede">Nodes are positioned by role — API calls on the left, files on the right — with drawn connectors showing exactly what produces or reuses what. Node color is the mutability class itself, not a separate key.</p>
+
+    <div class="legend">
+      <div class="legend-item"><span class="swatch" style="background:var(--fresh-soft);border-color:var(--fresh)"></span>overwritten every run</div>
+      <div class="legend-item"><span class="swatch" style="background:var(--immutable-soft);border-color:var(--immutable)"></span>write-once, immutable, shared</div>
+      <div class="legend-item"><span class="swatch" style="background:var(--merge-soft);border-color:var(--merge)"></span>merge-updated index</div>
+      <div class="legend-item"><span class="swatch" style="background:var(--api-soft);border-color:var(--api)"></span>API endpoint (nothing persisted as-is)</div>
+    </div>
+
+    <div class="rel-scroll">
+      <div class="relational-canvas">
+        <span class="col-label" style="left:30px">PUBG API</span>
+        <span class="col-label" style="left:680px">local files</span>
+
+        <svg class="edges" viewBox="0 0 960 760">
+          <defs>
+            <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse">
+              <path d="M0,0 L10,5 L0,10 Z"/>
+            </marker>
+          </defs>
+          <path d="M280,80 C430,80 530,75 680,75" stroke="var(--merge)" marker-end="url(#arrow)"/>
+          <path d="M155,130 L155,170" stroke="var(--api)" marker-end="url(#arrow)"/>
+          <path d="M280,220 C430,220 530,215 680,215" stroke="var(--fresh)" marker-end="url(#arrow)"/>
+          <path d="M805,260 C805,320 805,370 805,430" stroke="var(--immutable)" marker-end="url(#arrow)"/>
+          <path d="M680,480 C550,480 410,480 280,480" stroke="var(--immutable)" stroke-dasharray="5 4" marker-end="url(#arrow)"/>
+          <path d="M155,530 L155,560" stroke="var(--api)" marker-end="url(#arrow)"/>
+          <path d="M280,610 C430,610 530,580 680,560" stroke="var(--immutable)" marker-end="url(#arrow)"/>
+          <path d="M805,600 C805,615 805,625 805,640" stroke="var(--merge)" marker-end="url(#arrow)"/>
+        </svg>
+
+        <div class="edge-label" style="left:480px; top:52px;">player_id, response discarded</div>
+        <div class="edge-label" style="left:480px; top:198px;">full response saved</div>
+        <div class="edge-label" style="left:850px; top:340px;">this player's match_ids trigger fetch</div>
+        <div class="edge-label" style="left:480px; top:462px;">cache miss → triggers metadata call</div>
+        <div class="edge-label" style="left:480px; top:592px;">full payload saved, write-once</div>
+        <div class="edge-label" style="left:850px; top:618px;">bots detected in that match</div>
+
+        <!-- shared-cache stack effect behind match-telemetry -->
+        <div class="rstack" style="left:696px; top:446px; width:250px; height:170px;"></div>
+        <div class="rstack" style="left:688px; top:438px; width:250px; height:170px;"></div>
+
+        <div class="rnode k-api" style="left:30px; top:30px; width:250px; height:100px;">
+          <div class="rnode-kind"><svg class="icon"><use href="#i-api"/></svg>API call</div>
+          <div class="rnode-title">GET /players?filter[playerNames]</div>
+          <div class="rnode-note">Resolves account ID. Called once per run.</div>
+        </div>
+
+        <div class="rnode k-api" style="left:30px; top:170px; width:250px; height:100px;">
+          <div class="rnode-kind"><svg class="icon"><use href="#i-api"/></svg>API call</div>
+          <div class="rnode-title">GET /seasons/lifetime</div>
+          <div class="rnode-note">Full lifetime stats for this player_id.</div>
+        </div>
+
+        <div class="rnode k-api" style="left:30px; top:430px; width:250px; height:100px;">
+          <div class="rnode-kind"><svg class="icon"><use href="#i-api"/></svg>API call</div>
+          <div class="rnode-title">GET /matches/{match_id}</div>
+          <div class="rnode-note">Metadata only, to extract the CDN asset URL. Skipped entirely if telemetry is already cached.</div>
+        </div>
+
+        <div class="rnode k-api" style="left:30px; top:560px; width:250px; height:100px;">
+          <div class="rnode-kind"><svg class="icon"><use href="#i-api"/></svg>API call</div>
+          <div class="rnode-title">GET {telemetry CDN URL}</div>
+          <div class="rnode-note">The actual telemetry payload, fetched from the CDN, not the PUBG API host.</div>
+        </div>
+
+        <div class="rnode k-merge" style="left:680px; top:30px; width:250px; height:90px;">
+          <div class="rnode-kind"><svg class="icon"><use href="#i-merge"/></svg>merge-updated</div>
+          <div class="rnode-title">player-index.json</div>
+          <div class="rnode-note">account_id → playername, last_seen, stats_file.</div>
+        </div>
+
+        <div class="rnode k-fresh" style="left:680px; top:170px; width:250px; height:90px;">
+          <div class="rnode-kind"><svg class="icon"><use href="#i-write"/></svg>overwritten every run</div>
+          <div class="rnode-title">playerstats/{name}.json</div>
+          <div class="rnode-note">No cache check — always re-fetched fresh.</div>
+        </div>
+
+        <div class="rnode k-immutable" style="left:680px; top:430px; width:250px; height:170px; z-index:2;">
+          <div class="rnode-kind"><svg class="icon"><use href="#i-shared"/></svg>write-once · shared</div>
+          <div class="rnode-title">match-telemetry/{match_id}-telemetry.json</div>
+          <div class="rnode-note">Keyed by match_id only. A match cached from looking up one player is reused automatically for any other player who shares it — one file can back many players' analyses.</div>
+        </div>
+
+        <div class="rnode k-merge" style="left:680px; top:640px; width:250px; height:90px;">
+          <div class="rnode-kind"><svg class="icon"><use href="#i-merge"/></svg>merge-updated</div>
+          <div class="rnode-title">bot-index.json</div>
+          <div class="rnode-note">matches_seen grows, records never removed.</div>
+        </div>
+      </div>
     </div>
 
     <div class="notes">
       <div class="note fresh">
         <strong>playerstats/{name}.json</strong>
-        Overwritten in full on every run &mdash; no cache check. Lifetime stats change as the player plays more, so staleness isn't acceptable here.
+        Full response saved in full on every run &mdash; lifetime stats change as the player plays more, so staleness isn't acceptable here.
       </div>
       <div class="note immutable">
-        <strong>match-telemetry/{match_id}-telemetry.json</strong>
-        <code>_is_cached()</code> checks <code>os.path.exists()</code> before either the metadata call or the CDN fetch even fire. Keyed by match_id only, so a match cached from one player's lookup is silently reused for any other player who shares it.
+        <strong>match-telemetry is the shared layer</strong>
+        <code>_is_cached()</code> gates both API calls above it. Because the key is match_id, not player, one fetch backs every player who shares that match.
       </div>
       <div class="note merge">
-        <strong>player-index.json / bot-index.json</strong>
-        Not their own API call &mdash; built from data already in flight. Loaded, updated in place, and rewritten whole; existing entries get fields refreshed, records are never removed.
-      </div>
-      <div class="note">
-        <strong>Endpoints that leave no trace</strong>
-        The <code>/players</code> lookup and the per-match <code>/matches/{id}</code> metadata call are both used only in-memory &mdash; one for an account ID, the other for a CDN URL &mdash; and neither response is written to disk.
-      </div>
-    </div>
-  </section>
-
-  <section class="panel" id="sequence">
-    <h2>main.py &mdash; real execution order</h2>
-    <p class="lede">One straight run for one player. The telemetry fetch loop only touches the network for matches missing from the shared cache; every analysis step after it reads that cache back off disk rather than re-deriving from the API responses.</p>
-
-    <div class="diagram-wrap">
-<pre class="mermaid">
-sequenceDiagram
-    participant U as you (CLI)
-    participant M as main.py
-    participant API as PUBG API
-    participant PI as player-index.json
-    participant PS as playerstats/{name}.json
-    participant TC as match-telemetry/ cache
-    participant BI as bot-index.json
-
-    U->>M: python main.py <playername>
-    M->>API: GET /players?filter[playerNames]=
-    API-->>M: player_id
-    M->>PI: update_player_index (create/merge)
-    M->>API: GET /players/{id}/seasons/lifetime
-    API-->>M: lifetime stats
-    M->>PS: save_json (overwrite)
-    M->>M: render stats table + match history
-
-    M->>M: extract this player's match_ids from relationships
-    loop each match_id
-        M->>TC: cached?
-        alt not cached
-            M->>API: GET /matches/{id} (metadata)
-            API-->>M: telemetry CDN URL
-            M->>API: GET {telemetry CDN URL}
-            API-->>M: telemetry payload
-            M->>TC: save {id}-telemetry.json (write-once)
-        else cached
-            TC-->>M: skip fetch
-        end
-    end
-
-    M->>TC: read telemetry for this player's match_ids
-    M->>M: compute + render combat stats
-    M->>M: select_scoped_match_ids (recency window/cap)
-    M->>TC: read telemetry for scoped match_ids
-    M->>M: compute + render Archetype Tag (tempo + range + weapon signature)
-    M->>M: compute + render Headline Number
-    M->>TC: find this player's most recent cached match
-    M->>M: compute + render last-match brief
-    M->>TC: find latest match in the ENTIRE shared cache (not player-scoped)
-    M->>M: detect_bots on that match
-    M->>BI: update_bot_index (merge)
-    M->>M: render bot summary
-</pre>
-    </div>
-
-    <div class="notes">
-      <div class="note merge">
-        <strong>player-index write lands early</strong>
-        <code>update_player_index</code> runs right after the account-ID lookup, before the lifetime-stats call even goes out &mdash; the index only needs the ID and the searched name, not the stats payload.
-      </div>
-      <div class="note">
-        <strong>Two different "latest match" queries</strong>
-        The last-match brief looks up this player's own most recent cached match. Bot detection deliberately looks up the most recent match across the whole shared cache &mdash; a stand-in for "your" last match until self-identity detection lands.
-      </div>
-      <div class="note">
-        <strong>Scoped set is computed once, reused twice</strong>
-        <code>select_scoped_match_ids</code> runs a single time; both the Archetype Tag and the Headline Number read from that same recency-windowed set instead of each rescanning the full telemetry cache independently.
+        <strong>Indexes aren't their own API call</strong>
+        player-index.json and bot-index.json are built from data already in flight elsewhere &mdash; loaded, updated in place, rewritten whole.
       </div>
     </div>
   </section>

--- a/docs/architecture/data-flow.html
+++ b/docs/architecture/data-flow.html
@@ -1,0 +1,426 @@
+<title>pubg-teammate-analysis — local data map</title>
+<style>
+  :root {
+    --bg: #f4f5f3;
+    --bg-raised: #ffffff;
+    --ink: #1b2321;
+    --ink-dim: #58635e;
+    --line: #d4d9d3;
+    --accent: #2f7d70;
+    --accent-ink: #ffffff;
+    --fresh: #2f6fa8;
+    --fresh-soft: #e4edf6;
+    --immutable: #a9782c;
+    --immutable-soft: #f6ecd7;
+    --merge: #6f5aa3;
+    --merge-soft: #ece7f6;
+    --derived: #58635e;
+    --code-bg: #e9ece7;
+    --shadow: 0 1px 2px rgba(20, 30, 25, 0.06), 0 8px 24px rgba(20, 30, 25, 0.05);
+  }
+
+  :root[data-theme="dark"] {
+    --bg: #121613;
+    --bg-raised: #181e1a;
+    --ink: #e7ece7;
+    --ink-dim: #93a19a;
+    --line: #2a322c;
+    --accent: #5fbfae;
+    --accent-ink: #0b1512;
+    --fresh: #7fb3e0;
+    --fresh-soft: #1c2a36;
+    --immutable: #e0b262;
+    --immutable-soft: #332a17;
+    --merge: #b6a4e6;
+    --merge-soft: #241f36;
+    --derived: #93a19a;
+    --code-bg: #1e2521;
+    --shadow: 0 1px 2px rgba(0, 0, 0, 0.3), 0 12px 28px rgba(0, 0, 0, 0.35);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      --bg: #121613;
+      --bg-raised: #181e1a;
+      --ink: #e7ece7;
+      --ink-dim: #93a19a;
+      --line: #2a322c;
+      --accent: #5fbfae;
+      --accent-ink: #0b1512;
+      --fresh: #7fb3e0;
+      --fresh-soft: #1c2a36;
+      --immutable: #e0b262;
+      --immutable-soft: #332a17;
+      --merge: #b6a4e6;
+      --merge-soft: #241f36;
+      --derived: #93a19a;
+      --code-bg: #1e2521;
+      --shadow: 0 1px 2px rgba(0, 0, 0, 0.3), 0 12px 28px rgba(0, 0, 0, 0.35);
+    }
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--ink);
+    font-family: ui-sans-serif, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .mono {
+    font-family: ui-monospace, "SF Mono", "Cascadia Code", "Roboto Mono", Menlo, Consolas, monospace;
+  }
+
+  header {
+    padding: 2.25rem clamp(1.25rem, 4vw, 3rem) 1.25rem;
+    border-bottom: 1px solid var(--line);
+    max-width: 1180px;
+    margin: 0 auto;
+  }
+
+  .eyebrow {
+    font-family: ui-monospace, "SF Mono", "Cascadia Code", "Roboto Mono", Menlo, Consolas, monospace;
+    font-size: 0.72rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin: 0 0 0.6rem;
+  }
+
+  h1 {
+    font-family: ui-monospace, "SF Mono", "Cascadia Code", "Roboto Mono", Menlo, Consolas, monospace;
+    font-size: clamp(1.4rem, 2.6vw, 1.85rem);
+    font-weight: 600;
+    margin: 0 0 0.5rem;
+    text-wrap: balance;
+    letter-spacing: -0.01em;
+  }
+
+  header p {
+    max-width: 62ch;
+    color: var(--ink-dim);
+    margin: 0;
+    font-size: 0.96rem;
+  }
+
+  nav.tabs {
+    max-width: 1180px;
+    margin: 0 auto;
+    padding: 1rem clamp(1.25rem, 4vw, 3rem) 0;
+    display: flex;
+    gap: 0.5rem;
+    border-bottom: 1px solid var(--line);
+    position: sticky;
+    top: 0;
+    background: var(--bg);
+    z-index: 5;
+  }
+
+  .tab-btn {
+    font-family: ui-monospace, "SF Mono", "Cascadia Code", "Roboto Mono", Menlo, Consolas, monospace;
+    font-size: 0.82rem;
+    letter-spacing: 0.02em;
+    background: transparent;
+    border: none;
+    color: var(--ink-dim);
+    padding: 0.65rem 0.9rem;
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+    margin-bottom: -1px;
+    transition: color 0.15s ease, border-color 0.15s ease;
+  }
+
+  .tab-btn:hover { color: var(--ink); }
+
+  .tab-btn.active {
+    color: var(--accent);
+    border-bottom-color: var(--accent);
+  }
+
+  .tab-btn:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+
+  main {
+    max-width: 1180px;
+    margin: 0 auto;
+    padding: 1.75rem clamp(1.25rem, 4vw, 3rem) 4rem;
+  }
+
+  .panel { display: none; }
+  .panel.active { display: block; }
+
+  .panel h2 {
+    font-family: ui-monospace, "SF Mono", "Cascadia Code", "Roboto Mono", Menlo, Consolas, monospace;
+    font-size: 1.05rem;
+    font-weight: 600;
+    margin: 0 0 0.35rem;
+  }
+
+  .panel > p.lede {
+    color: var(--ink-dim);
+    max-width: 68ch;
+    margin: 0 0 1.25rem;
+    font-size: 0.95rem;
+  }
+
+  .legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 1.1rem;
+    margin: 0 0 1.25rem;
+    padding: 0.85rem 1rem;
+    background: var(--bg-raised);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    box-shadow: var(--shadow);
+  }
+
+  .legend-item {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    font-size: 0.8rem;
+    color: var(--ink-dim);
+  }
+
+  .swatch {
+    width: 0.7rem;
+    height: 0.7rem;
+    border-radius: 2px;
+    flex: none;
+  }
+
+  .diagram-wrap {
+    background: var(--bg-raised);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    box-shadow: var(--shadow);
+    padding: 1.25rem;
+    overflow-x: auto;
+  }
+
+  .diagram-wrap pre.mermaid {
+    margin: 0;
+    min-width: 720px;
+  }
+
+  .notes {
+    margin-top: 1.5rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 0.9rem;
+  }
+
+  .note {
+    background: var(--bg-raised);
+    border: 1px solid var(--line);
+    border-left: 3px solid var(--accent-line, var(--accent));
+    border-radius: 6px;
+    padding: 0.85rem 1rem;
+    font-size: 0.85rem;
+    color: var(--ink-dim);
+  }
+
+  .note strong {
+    display: block;
+    color: var(--ink);
+    font-size: 0.82rem;
+    margin-bottom: 0.25rem;
+    font-family: ui-monospace, "SF Mono", "Cascadia Code", "Roboto Mono", Menlo, Consolas, monospace;
+  }
+
+  .note code {
+    font-family: ui-monospace, "SF Mono", "Cascadia Code", "Roboto Mono", Menlo, Consolas, monospace;
+    background: var(--code-bg);
+    padding: 0.1rem 0.35rem;
+    border-radius: 4px;
+    font-size: 0.82em;
+  }
+
+  .note.fresh { border-left-color: var(--fresh); }
+  .note.immutable { border-left-color: var(--immutable); }
+  .note.merge { border-left-color: var(--merge); }
+
+  footer {
+    max-width: 1180px;
+    margin: 0 auto;
+    padding: 0 clamp(1.25rem, 4vw, 3rem) 3rem;
+    color: var(--ink-dim);
+    font-size: 0.78rem;
+  }
+
+  footer code { font-family: ui-monospace, "SF Mono", "Cascadia Code", "Roboto Mono", Menlo, Consolas, monospace; }
+
+  @media (prefers-reduced-motion: reduce) {
+    * { transition: none !important; }
+  }
+</style>
+
+<header>
+  <p class="eyebrow">pubg-teammate-analysis / local data map</p>
+  <h1>What a single run reads, writes, and reuses</h1>
+  <p>Two views of the same system: which local files each API call feeds (or gets fed by), and the actual execution order inside a <code class="mono">python main.py &lt;playername&gt;</code> run.</p>
+</header>
+
+<nav class="tabs">
+  <button class="tab-btn active" data-tab="relationships">Relationships</button>
+  <button class="tab-btn" data-tab="sequence">Execution order</button>
+</nav>
+
+<main>
+  <section class="panel active" id="relationships">
+    <h2>API calls &rarr; local files</h2>
+    <p class="lede">Nodes are either a live PUBG API call or a file this project writes. Edges show what produces or reads what. Color marks how each file behaves across repeated runs &mdash; that behavior is the whole reason the caching layer exists.</p>
+
+    <div class="legend">
+      <div class="legend-item"><span class="swatch" style="background:var(--fresh)"></span>re-fetched every run (overwritten)</div>
+      <div class="legend-item"><span class="swatch" style="background:var(--immutable)"></span>write-once, immutable (cache-gated)</div>
+      <div class="legend-item"><span class="swatch" style="background:var(--merge)"></span>merge-updated index (never deleted from)</div>
+      <div class="legend-item"><span class="swatch" style="background:var(--ink-dim)"></span>API endpoint (response not persisted as-is)</div>
+    </div>
+
+    <div class="diagram-wrap">
+<pre class="mermaid">
+flowchart LR
+    A1["GET /players?filter[playerNames]=name<br/>resolve account ID"]
+    A2["GET /players/{id}/seasons/lifetime"]
+    A3["GET /matches/{match_id}<br/>metadata, for CDN asset URL"]
+    A4["GET {telemetry CDN URL}<br/>raw telemetry payload"]
+
+    PS["playerstats/{name}.json"]
+    PI["player-index.json"]
+    TM["match-telemetry/{match_id}-telemetry.json<br/>(shared across every player)"]
+    BI["bot-index.json"]
+
+    A1 -->|player_id, response discarded| PI
+    A1 -->|player_id feeds next call| A2
+    A2 -->|full response saved| PS
+    PS -->|this player's match_ids, from relationships| TM
+    TM -.->|_is_cached? miss triggers| A3
+    A3 -->|asset URL, response discarded| A4
+    A4 -->|full payload saved| TM
+    TM -->|detect_bots on latest cached match| BI
+
+    class A1,A2,A3,A4 api
+    class PS fresh
+    class TM immutable
+    class PI,BI merge
+
+    classDef api fill:#dfe3de,stroke:#58635e,color:#1b2321,stroke-width:1px;
+    classDef fresh fill:#dbe7f5,stroke:#2f6fa8,color:#122236;
+    classDef immutable fill:#f3e2bb,stroke:#a9782c,color:#3b2a0c;
+    classDef merge fill:#e4dcf4,stroke:#6f5aa3,color:#251c3d;
+</pre>
+    </div>
+
+    <div class="notes">
+      <div class="note fresh">
+        <strong>playerstats/{name}.json</strong>
+        Overwritten in full on every run &mdash; no cache check. Lifetime stats change as the player plays more, so staleness isn't acceptable here.
+      </div>
+      <div class="note immutable">
+        <strong>match-telemetry/{match_id}-telemetry.json</strong>
+        <code>_is_cached()</code> checks <code>os.path.exists()</code> before either the metadata call or the CDN fetch even fire. Keyed by match_id only, so a match cached from one player's lookup is silently reused for any other player who shares it.
+      </div>
+      <div class="note merge">
+        <strong>player-index.json / bot-index.json</strong>
+        Not their own API call &mdash; built from data already in flight. Loaded, updated in place, and rewritten whole; existing entries get fields refreshed, records are never removed.
+      </div>
+      <div class="note">
+        <strong>Endpoints that leave no trace</strong>
+        The <code>/players</code> lookup and the per-match <code>/matches/{id}</code> metadata call are both used only in-memory &mdash; one for an account ID, the other for a CDN URL &mdash; and neither response is written to disk.
+      </div>
+    </div>
+  </section>
+
+  <section class="panel" id="sequence">
+    <h2>main.py &mdash; real execution order</h2>
+    <p class="lede">One straight run for one player. The telemetry fetch loop only touches the network for matches missing from the shared cache; every analysis step after it reads that cache back off disk rather than re-deriving from the API responses.</p>
+
+    <div class="diagram-wrap">
+<pre class="mermaid">
+sequenceDiagram
+    participant U as you (CLI)
+    participant M as main.py
+    participant API as PUBG API
+    participant PI as player-index.json
+    participant PS as playerstats/{name}.json
+    participant TC as match-telemetry/ cache
+    participant BI as bot-index.json
+
+    U->>M: python main.py <playername>
+    M->>API: GET /players?filter[playerNames]=
+    API-->>M: player_id
+    M->>PI: update_player_index (create/merge)
+    M->>API: GET /players/{id}/seasons/lifetime
+    API-->>M: lifetime stats
+    M->>PS: save_json (overwrite)
+    M->>M: render stats table + match history
+
+    M->>M: extract this player's match_ids from relationships
+    loop each match_id
+        M->>TC: cached?
+        alt not cached
+            M->>API: GET /matches/{id} (metadata)
+            API-->>M: telemetry CDN URL
+            M->>API: GET {telemetry CDN URL}
+            API-->>M: telemetry payload
+            M->>TC: save {id}-telemetry.json (write-once)
+        else cached
+            TC-->>M: skip fetch
+        end
+    end
+
+    M->>TC: read telemetry for this player's match_ids
+    M->>M: compute + render combat stats
+    M->>M: select_scoped_match_ids (recency window/cap)
+    M->>TC: read telemetry for scoped match_ids
+    M->>M: compute + render Archetype Tag (tempo + range + weapon signature)
+    M->>M: compute + render Headline Number
+    M->>TC: find this player's most recent cached match
+    M->>M: compute + render last-match brief
+    M->>TC: find latest match in the ENTIRE shared cache (not player-scoped)
+    M->>M: detect_bots on that match
+    M->>BI: update_bot_index (merge)
+    M->>M: render bot summary
+</pre>
+    </div>
+
+    <div class="notes">
+      <div class="note merge">
+        <strong>player-index write lands early</strong>
+        <code>update_player_index</code> runs right after the account-ID lookup, before the lifetime-stats call even goes out &mdash; the index only needs the ID and the searched name, not the stats payload.
+      </div>
+      <div class="note">
+        <strong>Two different "latest match" queries</strong>
+        The last-match brief looks up this player's own most recent cached match. Bot detection deliberately looks up the most recent match across the whole shared cache &mdash; a stand-in for "your" last match until self-identity detection lands.
+      </div>
+      <div class="note">
+        <strong>Scoped set is computed once, reused twice</strong>
+        <code>select_scoped_match_ids</code> runs a single time; both the Archetype Tag and the Headline Number read from that same recency-windowed set instead of each rescanning the full telemetry cache independently.
+      </div>
+    </div>
+  </section>
+</main>
+
+<footer>
+  Source of truth: <code>main.py</code>, <code>api/player_stats.py</code>, <code>api/telemetry_fetcher.py</code>, <code>api/player_index.py</code>, <code>api/bot_index.py</code>, <code>utils/io_helpers.py</code>. <code>api/rate_limiter.py</code> paces requests in memory only &mdash; no persisted state.
+</footer>
+
+<script>
+  var buttons = document.querySelectorAll(".tab-btn");
+  var panels = document.querySelectorAll(".panel");
+  buttons.forEach(function (btn) {
+    btn.addEventListener("click", function () {
+      buttons.forEach(function (b) { b.classList.remove("active"); });
+      panels.forEach(function (p) { p.classList.remove("active"); });
+      btn.classList.add("active");
+      document.getElementById(btn.dataset.tab).classList.add("active");
+    });
+  });
+</script>

--- a/docs/design/storyboard-profile.md
+++ b/docs/design/storyboard-profile.md
@@ -13,7 +13,7 @@ post-match coaching actually values.
 - [ ] Map Drop Zone + Flow (primary + secondary landing region, per-region flow)
 - [x] The Headline Number (one differentiating, confidence-gated stat) - see `utils/headline_number.py`
 - [x] Weapon Signature (or honest "Wildcard" framing when there's no clear pattern) - see `utils/weapon_signature.py`
-- [ ] Last Match Snapshot (extends #13, adds squad-status-at-death)
+- [x] Last Match Snapshot (extends #13, adds squad-status-at-death) - see `utils/last_match_brief.py`'s `_compute_squad_status_at_death`
 - [ ] Squad Read (synergy/gap line, bolstered when high-confidence)
 - [ ] Squad Roster summary view (Squads mode, 2+ teammates)
 - [ ] Mode 2: After-Action Report (conceptual scope only)
@@ -450,3 +450,16 @@ candidates (win rate, conversion rate) use a one-sample z-test for a
 proportion against a neutral 50/50 split; magnitude-type candidates
 (kills, revives, damage) use a one-sample t-statistic against a neutral
 zero. Falls back to a plain kill count when nothing clears the bar.
+
+Resolved: Last Match Snapshot's squad-status-at-death cross-reference is
+implemented in `utils/last_match_brief.py` (`_compute_squad_status_at_death`).
+Each teammate (same `teamId`, real player) is classified as still alive,
+went down in the same fight, or eliminated earlier and unrelated, by
+comparing their own first real death timestamp against this player's death
+timestamp. The same-fight cutoff (`SAME_ENGAGEMENT_WINDOW_SECONDS = 30`) is
+grounded in real data - checked against 10,744 real teammate-death-gap
+timings across 250 cached squad matches, which showed no clean bimodal
+split, but whose p60 (~29s) lines up closely with `tempo_signal.py`'s
+independently-calibrated `QUICK_KILL_WINDOW_SECONDS` (30s), so the same
+window is reused rather than introducing a second, unrelated constant for
+a similar "quick/connected" question.

--- a/docs/design/storyboard-profile.md
+++ b/docs/design/storyboard-profile.md
@@ -15,7 +15,7 @@ post-match coaching actually values.
 - [x] Weapon Signature (or honest "Wildcard" framing when there's no clear pattern) - see `utils/weapon_signature.py`
 - [x] Last Match Snapshot (extends #13, adds squad-status-at-death) - see `utils/last_match_brief.py`'s `_compute_squad_status_at_death`
 - [x] Squad Read (synergy/gap line, bolstered when high-confidence) - see `utils/squad_read.py`; compute module only, not yet wired into a multi-player CLI flow (see the Resolved note below)
-- [ ] Squad Roster summary view (Squads mode, 2+ teammates)
+- [x] Squad Roster summary view (Squads mode, 2+ teammates) - see `utils/squad_roster.py` and `squad.py` (new multi-player entry point)
 - [ ] Mode 2: After-Action Report (conceptual scope only)
 - [ ] Solo mode variant (conceptual scope only)
 - [x] Data Budget & Fetch Policy - see `utils/match_scope.py` (recency-window + match-count cap, both env-configurable)
@@ -424,14 +424,6 @@ since there's no detection code to log from.
   coordinate bounds)
 - Mode 2's full slot design (this doc only scopes it conceptually)
 - The specific failsafe hotkey combination
-- Multi-player CLI wiring so Squad Read/Squad Roster are runnable
-  end-to-end (today `main.py` only profiles one player per run) - planned
-  as a combined follow-up for both slots: a separate entry point reusing
-  the existing single-player functions untouched, one deduplicated
-  telemetry fetch across all squad members instead of one per player, and
-  concurrent player-stats fetches (safe today - `api/rate_limiter.py`'s
-  queue already serializes via an `asyncio.Lock` regardless of caller
-  count).
 
 Resolved: Archetype tempo bucket thresholds and range-axis thresholds are
 both calibrated against real telemetry (1,636 cached matches, including
@@ -483,5 +475,30 @@ compares them within the same shared match; the confidence bar is the
 doc's own literal worked example - most recent 8 shared matches, at least
 5 needed to name a leader (the doc's parenthetical "~70%+" doesn't match
 5/8 exactly, so the concrete numeric example was treated as authoritative
-over the loose gloss). Compute module only for now - see the open
-question above on multi-player CLI wiring.
+over the loose gloss).
+
+Resolved: Multi-player CLI support landed as `squad.py`, a genuinely
+separate entry point from `main.py` rather than a mode switch inside it -
+the single-player flow is untouched (verified: identical output before
+and after, plus a full end-to-end live re-run). It fetches all squad
+members' player stats concurrently (safe today - `api/rate_limiter.py`'s
+queue already serializes the actual HTTP calls via an `asyncio.Lock`
+regardless of caller count), then does one combined, deduplicated
+telemetry fetch across the whole squad instead of one per player, so a
+match two teammates shared only gets pulled once and the per-run new-
+match cap applies to the squad as a whole rather than multiplying by
+squad size. Verified live against two real players with 53 shared cached
+matches: 79 combined unique matches identified, cache dedup and telemetry
+fetch worked correctly end to end.
+
+Resolved: Squad Roster's squad-level synergy text
+(`utils/squad_roster.py`) generalizes Squad Read's compositional approach
+to N players rather than stitching together pairwise comparisons: range-
+bucket coverage (which buckets are represented, which are missing) and
+temperament distribution across the whole squad, with per-member role
+callouts ("entry fragger", "support anchor") derived from that member's
+own (range, temperament) pair - not a hand-authored table of squad-
+composition combos. The bolstered "opens first" line compares "you"
+against each teammate and surfaces whichever comparison is strongest,
+matching the design doc's mockup (one standout teammate highlighted, not
+one line per pairing).

--- a/docs/design/storyboard-profile.md
+++ b/docs/design/storyboard-profile.md
@@ -14,7 +14,7 @@ post-match coaching actually values.
 - [x] The Headline Number (one differentiating, confidence-gated stat) - see `utils/headline_number.py`
 - [x] Weapon Signature (or honest "Wildcard" framing when there's no clear pattern) - see `utils/weapon_signature.py`
 - [x] Last Match Snapshot (extends #13, adds squad-status-at-death) - see `utils/last_match_brief.py`'s `_compute_squad_status_at_death`
-- [ ] Squad Read (synergy/gap line, bolstered when high-confidence)
+- [x] Squad Read (synergy/gap line, bolstered when high-confidence) - see `utils/squad_read.py`; compute module only, not yet wired into a multi-player CLI flow (see the Resolved note below)
 - [ ] Squad Roster summary view (Squads mode, 2+ teammates)
 - [ ] Mode 2: After-Action Report (conceptual scope only)
 - [ ] Solo mode variant (conceptual scope only)
@@ -424,6 +424,14 @@ since there's no detection code to log from.
   coordinate bounds)
 - Mode 2's full slot design (this doc only scopes it conceptually)
 - The specific failsafe hotkey combination
+- Multi-player CLI wiring so Squad Read/Squad Roster are runnable
+  end-to-end (today `main.py` only profiles one player per run) - planned
+  as a combined follow-up for both slots: a separate entry point reusing
+  the existing single-player functions untouched, one deduplicated
+  telemetry fetch across all squad members instead of one per player, and
+  concurrent player-stats fetches (safe today - `api/rate_limiter.py`'s
+  queue already serializes via an `asyncio.Lock` regardless of caller
+  count).
 
 Resolved: Archetype tempo bucket thresholds and range-axis thresholds are
 both calibrated against real telemetry (1,636 cached matches, including
@@ -463,3 +471,17 @@ split, but whose p60 (~29s) lines up closely with `tempo_signal.py`'s
 independently-calibrated `QUICK_KILL_WINDOW_SECONDS` (30s), so the same
 window is reused rather than introducing a second, unrelated constant for
 a similar "quick/connected" question.
+
+Resolved: Squad Read's general synergy line is implemented in
+`utils/squad_read.py` as compositional logic (range-bucket delta +
+temperament delta between two players), not a hand-authored lookup table
+of named roles - scales to any pairing without maintaining a combo table,
+and stays consistent with how the other signals derive behavior from raw
+data rather than fixed categories. The bolstered "opens first" line reuses
+`tempo_signal.py`'s own time-to-first-contact reading for each player and
+compares them within the same shared match; the confidence bar is the
+doc's own literal worked example - most recent 8 shared matches, at least
+5 needed to name a leader (the doc's parenthetical "~70%+" doesn't match
+5/8 exactly, so the concrete numeric example was treated as authoritative
+over the loose gloss). Compute module only for now - see the open
+question above on multi-player CLI wiring.

--- a/docs/design/storyboard-profile.md
+++ b/docs/design/storyboard-profile.md
@@ -424,6 +424,16 @@ since there's no detection code to log from.
   coordinate bounds)
 - Mode 2's full slot design (this doc only scopes it conceptually)
 - The specific failsafe hotkey combination
+- Persona label variety: the current taxonomy is intentionally small (5
+  tempo tags, a 3x3 range/temperament grid) - a deliberate choice made
+  across both Archetype Tag ("plain fields... rather than an invented
+  flavor-text headline") and Squad Read (compositional logic over a
+  hand-authored role table), not an oversight. If richer/more varied
+  persona language becomes a priority later, `docs/vision.md`'s existing
+  stance is to keep LLM narration out of scope until core capabilities
+  are stable - flagged as a future LLM-personalization candidate once
+  that's revisited, not something to bolt onto the current rule-based
+  system piecemeal.
 
 Resolved: Archetype tempo bucket thresholds and range-axis thresholds are
 both calibrated against real telemetry (1,636 cached matches, including
@@ -502,3 +512,24 @@ composition combos. The bolstered "opens first" line compares "you"
 against each teammate and surfaces whichever comparison is strongest,
 matching the design doc's mockup (one standout teammate highlighted, not
 one line per pairing).
+
+Resolved: Did a full sentence-to-math audit across every text-generating
+module before the Mode 1 PR - not just "does it run," but "does every
+displayed sentence accurately restate the specific computed value behind
+it." Traced every branch by hand against real captured output and the
+underlying source data. Found and fixed two real mismatches: (1)
+`display_archetype_tag.py` labeled `tempo_signal.py`'s
+`matches_with_contact` as "matches with early contact," but that count
+includes contact at any point in the match, not specifically early
+contact - the word "early" wasn't supported by the underlying value, so
+it was dropped. (2) Two Headline Number candidates
+(`kills_before_death`, `revives`) carried a fixed narrative flourish
+("...they don't stop early", "...the squad's safety net") regardless of
+whether the actual computed mean was high or low - removed both, stating
+the number plainly, consistent with the project's existing stance against
+invented flavor text. Everything else checked (tempo bucket assignment,
+range/weapon signature framing, squad synergy branch logic, squad roster
+role callouts and coverage gaps, engagement-lead threshold framing) was
+confirmed to correctly and exclusively reflect its underlying data, with
+no case where the displayed label could exist independent of the
+specific values shown.

--- a/docs/design/storyboard-profile.md
+++ b/docs/design/storyboard-profile.md
@@ -11,7 +11,7 @@ post-match coaching actually values.
 
 - [x] Archetype Tag (headline label: range + tempo + signature weapon) - see `utils/archetype_tag.py`; presented as plain tempo/range/weapon fields plus a short `Range/Temperament` tag rather than an invented flavor-text headline
 - [ ] Map Drop Zone + Flow (primary + secondary landing region, per-region flow)
-- [ ] The Headline Number (one differentiating, confidence-gated stat)
+- [x] The Headline Number (one differentiating, confidence-gated stat) - see `utils/headline_number.py`
 - [x] Weapon Signature (or honest "Wildcard" framing when there's no clear pattern) - see `utils/weapon_signature.py`
 - [ ] Last Match Snapshot (extends #13, adds squad-status-at-death)
 - [ ] Squad Read (synergy/gap line, bolstered when high-confidence)
@@ -432,3 +432,21 @@ top-30 ranked PC-NA leaderboard players) - see `utils/tempo_signal.py` and
 implemented in `utils/match_scope.py`, currently set low (50 matches)
 pending a dedicated performance pass, not yet the intended production
 default (250).
+
+Resolved: The Headline Number's candidate pool, eligibility gate,
+stability check, and scoring are implemented in `utils/headline_number.py`.
+Five candidates cover the PEPS+ categories the doc calls out (Firepower,
+Finishing, Combat Distance, plus a team-support read via revives): avg
+kills before first death, close-range fight win rate, knockdown-to-kill
+conversion rate, revives per match, damage per match. Eligibility requires
+`MIN_MATCHES_FOR_CANDIDATE = 8` matches of underlying data, matching the
+threshold used across the other Archetype Tag signals. Stability is a
+chronological first-half/second-half check requiring the same direction
+of deviation from a neutral reference in both halves, with neither half's
+deviation dwarfing the other's. Scoring uses two standard, self-relative
+statistical tests rather than one blended formula, since a single formula
+turned out to blow up for count-type stats at large magnitudes: rate-type
+candidates (win rate, conversion rate) use a one-sample z-test for a
+proportion against a neutral 50/50 split; magnitude-type candidates
+(kills, revives, damage) use a one-sample t-statistic against a neutral
+zero. Falls back to a plain kill count when nothing clears the bar.

--- a/main.py
+++ b/main.py
@@ -16,6 +16,9 @@ from utils.last_match_brief import find_latest_match_for_player, compute_last_ma
 from utils.display_last_match_brief import render_last_match_brief
 from utils.archetype_tag import compute_archetype_tag
 from utils.display_archetype_tag import render_archetype_tag
+from utils.headline_number import compute_headline_number
+from utils.display_headline_number import render_headline_number
+from utils.match_scope import select_scoped_match_ids
 import asyncio
 
 
@@ -59,10 +62,20 @@ async def _run(playername):
     combat_stats = compute_combat_stats(player_id)
     render_combat_stats(combat_stats)
 
+    # Resolve the player's scoped match set once and reuse it across both
+    # signal computations below, rather than each one independently
+    # rescanning the full shared telemetry cache.
+    scoped_match_ids = set(select_scoped_match_ids(player_id))
+
     # Display Archetype Tag (tempo + range + weapon signature) mined from cached telemetry
     print("\n\n")
-    archetype = compute_archetype_tag(player_id)
+    archetype = compute_archetype_tag(player_id, match_ids=scoped_match_ids)
     render_archetype_tag(archetype)
+
+    # Display the Headline Number: one differentiating, confidence-gated stat
+    print("\n\n")
+    headline = compute_headline_number(player_id, match_ids=scoped_match_ids)
+    render_headline_number(headline)
 
     # Last Match section: brief for this player, then bot detection for
     # whichever cached match is most recent overall (a stand-in for "your"

--- a/main.py
+++ b/main.py
@@ -1,9 +1,8 @@
 # ==============================
 # main CLI entry point
 # ==============================
-from api.player_stats import fetch_player_stats
+from api.player_stats import fetch_player_and_match_ids
 from api.rate_limiter import player_api_queue
-from utils.io_helpers import save_json
 from utils.display_stats_by_mode import render_ascii_table, load_player_stats
 from utils.display_match_history import display_match_history
 from api.telemetry_fetcher import fetch_telemetry_for_matches
@@ -31,8 +30,7 @@ async def run(playername):
         await player_api_queue.close()
 
 async def _run(playername):
-    data, player_id = await fetch_player_stats(playername)
-    save_json(data, f"playerstats/{playername}.json")
+    player_id, match_ids = await fetch_player_and_match_ids(playername)
     print(f"[SUCCESS] Stats saved for '{playername}' (account ID: {player_id})")
     print()
     print()
@@ -44,13 +42,6 @@ async def _run(playername):
     # Display match history grouped by mode
     print("\n\n")
     display_match_history(playername)
-
-    # Fetch telemetry for all matches
-    match_ids = []
-    relationships = data["data"]["relationships"]
-    for key in relationships:
-        if key.startswith("matches"):
-            match_ids.extend([entry["id"] for entry in relationships[key].get("data", [])])
 
     print()
     print()

--- a/main.py
+++ b/main.py
@@ -59,13 +59,15 @@ async def _run(playername):
 
     # Display combat stats mined from cached telemetry
     print("\n\n")
-    combat_stats = compute_combat_stats(player_id)
+    combat_stats = compute_combat_stats(player_id, match_ids=match_ids)
     render_combat_stats(combat_stats)
 
     # Resolve the player's scoped match set once and reuse it across both
     # signal computations below, rather than each one independently
-    # rescanning the full shared telemetry cache.
-    scoped_match_ids = set(select_scoped_match_ids(player_id))
+    # rescanning the telemetry cache. match_ids (this player's own known
+    # matches, from the player-stats API response above) is the candidate
+    # list - never the whole shared cache, which holds other players' too.
+    scoped_match_ids = set(select_scoped_match_ids(match_ids))
 
     # Display Archetype Tag (tempo + range + weapon signature) mined from cached telemetry
     print("\n\n")
@@ -83,7 +85,7 @@ async def _run(playername):
     print("\n\n")
     latest_match_id, latest_events = find_latest_match()
 
-    player_match_id, player_events = find_latest_match_for_player(player_id)
+    player_match_id, player_events = find_latest_match_for_player(player_id, match_ids)
     if player_match_id:
         brief = compute_last_match_brief(player_id, player_match_id, player_events)
         played_with_you = (player_match_id == latest_match_id) if latest_match_id else None

--- a/squad.py
+++ b/squad.py
@@ -1,0 +1,90 @@
+# ==============================
+# squad CLI entry point - profile an entire squad at once
+# ==============================
+"""
+Profile a whole squad (2+ players) in one run: fetches/refreshes each
+player's stats concurrently, shares one deduplicated telemetry fetch
+across the whole squad (a match two teammates played together only needs
+pulling once), then renders the Squad Roster - a coverage/distribution
+summary plus a full Archetype Tag + Headline Number card per teammate.
+
+Kept as a genuinely separate entry point from main.py rather than a mode
+switch inside it, so the single-player flow (main.py <playername>) stays
+completely untouched.
+"""
+import argparse
+import asyncio
+
+from api.player_stats import fetch_player_and_match_ids
+from api.rate_limiter import player_api_queue
+from api.telemetry_fetcher import fetch_telemetry_for_matches
+from utils.archetype_tag import compute_archetype_tag
+from utils.headline_number import compute_headline_number
+from utils.match_scope import select_scoped_match_ids
+from utils.squad_roster import compute_squad_roster
+from utils.display_squad_roster import render_squad_roster, render_full_squad_cards
+
+
+async def run(playernames):
+    try:
+        await _run(playernames)
+    finally:
+        await player_api_queue.close()
+
+
+async def _run(playernames):
+    # Concurrent player-stats fetch across the squad - safe today since
+    # api/rate_limiter.py's queue already serializes the actual HTTP calls
+    # via an asyncio.Lock regardless of how many callers use it at once.
+    fetched = await asyncio.gather(*(fetch_player_and_match_ids(name) for name in playernames))
+
+    members = []
+    for name, (account_id, match_ids) in zip(playernames, fetched):
+        print(f"[SUCCESS] Stats saved for '{name}' (account ID: {account_id})")
+        members.append({"name": name, "account_id": account_id, "match_ids": match_ids})
+
+    # One combined, deduplicated telemetry fetch for the whole squad - a
+    # match two teammates played together only needs pulling once
+    # (fetch_telemetry_for_matches already skips already-cached matches),
+    # and this keeps the per-run new-match cap meaningful for the squad as
+    # a whole rather than effectively multiplying it by squad size.
+    all_match_ids = set()
+    for m in members:
+        all_match_ids.update(m["match_ids"])
+    print()
+    print(f"[INFO] Fetching telemetry for {len(all_match_ids)} unique matches across {len(playernames)} players...")
+    await fetch_telemetry_for_matches(list(all_match_ids))
+
+    archetypes = {}
+    headlines = {}
+    for m in members:
+        scoped = set(select_scoped_match_ids(m["match_ids"]))
+        archetype = compute_archetype_tag(m["account_id"], match_ids=scoped)
+        m["archetype"] = archetype
+        archetypes[m["name"]] = archetype
+        headlines[m["name"]] = compute_headline_number(m["account_id"], match_ids=scoped)
+
+    roster = compute_squad_roster(members)
+
+    print("\n\n")
+    render_squad_roster(roster)
+    render_full_squad_cards(members, archetypes, headlines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Profile a full squad (2+ players) at once.")
+    parser.add_argument("playernames", nargs="+", help="PUBG player names in the squad, you first")
+    args = parser.parse_args()
+
+    if len(args.playernames) < 2:
+        print("[ERROR] Provide at least 2 player names for a squad lookup (you first, then teammates).")
+        return
+
+    try:
+        asyncio.run(run(args.playernames))
+    except Exception as e:
+        print(f"[ERROR] {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_display_stats_by_mode.py
+++ b/tests/test_display_stats_by_mode.py
@@ -18,13 +18,8 @@ class TestFormatNumber(unittest.TestCase):
     def test_converts_time_survived_seconds_to_minutes(self):
         self.assertEqual(format_number(120, key="longestTimeSurvived"), "2")
 
-    def test_time_survived_key_does_not_match_case_sensitive_check(self):
-        # Documents current behavior: "timeSurvived" (lowercase t) does not
-        # match the "TimeSurvived" substring check, so it's formatted as a
-        # plain number rather than converted from seconds to minutes. See
-        # the "Time Survived (min)" row mislabeling flagged in issue #17's
-        # test audit - tracked separately, not fixed here.
-        self.assertEqual(format_number(120, key="timeSurvived"), "120")
+    def test_time_survived_lowercase_key_converts_to_minutes(self):
+        self.assertEqual(format_number(120, key="timeSurvived"), "2")
 
     def test_non_numeric_value_defaults_to_zero(self):
         self.assertEqual(format_number(None), "0")

--- a/tests/test_headline_number.py
+++ b/tests/test_headline_number.py
@@ -1,0 +1,203 @@
+##########
+# Unit Test for Headline Number (confidence-gated "so-what" stat picker)
+# from root of project: `python -m unittest discover tests`
+##########
+
+import json
+import os
+import tempfile
+import unittest
+
+from utils.headline_number import compute_headline_number, MIN_MATCHES_FOR_CANDIDATE
+
+ME = "account.me"
+RIVAL = "account.rival"
+TEAMMATE = "account.teammate"
+
+
+def match_start(day):
+    return {"_T": "LogMatchStart", "_D": f"2026-07-{day:02d}T00:00:00.000Z"}
+
+
+def create_event(account_id):
+    return {"_T": "LogPlayerCreate", "character": {"accountId": account_id, "type": "user"}}
+
+
+def kill_event(killer_id, victim_id, distance_m=10, killer_type="user", victim_type="user",
+               is_suicide=False, dbno_id=-1):
+    return {
+        "_T": "LogPlayerKillV2",
+        "isSuicide": is_suicide,
+        "dBNOId": dbno_id,
+        "killer": {"accountId": killer_id, "type": killer_type},
+        "victim": {"accountId": victim_id, "type": victim_type},
+        "killerDamageInfo": {"distance": distance_m * 100},
+    }
+
+
+def damage_event(attacker_id, victim_id, damage, attacker_type="user", victim_type="user"):
+    return {
+        "_T": "LogPlayerTakeDamage",
+        "attacker": {"accountId": attacker_id, "type": attacker_type},
+        "victim": {"accountId": victim_id, "type": victim_type},
+        "damage": damage,
+    }
+
+
+def revive_event(reviver_id, victim_id):
+    return {"_T": "LogPlayerRevive", "reviver": {"accountId": reviver_id}, "victim": {"accountId": victim_id}}
+
+
+def groggy_event(attacker_id, victim_id, dbno_id, attacker_type="user", victim_type="user"):
+    return {
+        "_T": "LogPlayerMakeGroggy",
+        "dBNOId": dbno_id,
+        "attacker": {"accountId": attacker_id, "type": attacker_type},
+        "victim": {"accountId": victim_id, "type": victim_type},
+    }
+
+
+class TestComputeHeadlineNumber(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+
+    def _write_match(self, day, events):
+        match_id = f"match-{day}"
+        path = os.path.join(self.tmpdir.name, f"{match_id}-telemetry.json")
+        with open(path, "w") as f:
+            json.dump([match_start(day), create_event(ME)] + events, f)
+        return match_id
+
+    def test_below_minimum_matches_falls_back_to_kill_count(self):
+        for day in range(1, MIN_MATCHES_FOR_CANDIDATE - 1):
+            self._write_match(day, [kill_event(ME, RIVAL)])
+
+        result = compute_headline_number(ME, telemetry_dir=self.tmpdir.name)
+
+        self.assertEqual(result["stat_key"], "fallback_kill_count")
+        self.assertIsNone(result["score"])
+        self.assertIn("kills over your last", result["headline"])
+
+    def test_no_matches_reports_not_enough_data(self):
+        result = compute_headline_number(ME, telemetry_dir=self.tmpdir.name)
+
+        self.assertEqual(result["headline"], "Not enough data yet")
+        self.assertEqual(result["matches_analyzed"], 0)
+
+    def test_stable_close_range_win_rate_selected(self):
+        # Wins every close-range fight, consistently, across enough matches -
+        # a clean, stable rate signal.
+        # Always dies (never kills) at close range - a clean, consistently
+        # one-sided rate signal. Deliberately the "loses every time" shape
+        # rather than "wins every time": a win is itself a real kill, which
+        # would also feed the kills-before-death candidate and make the two
+        # signals move together instead of isolating this one.
+        for day in range(1, 13):
+            self._write_match(day, [kill_event(RIVAL, ME, distance_m=8)])
+
+        result = compute_headline_number(ME, telemetry_dir=self.tmpdir.name)
+
+        self.assertEqual(result["stat_key"], "close_range_win_rate")
+        self.assertIn("0%", result["headline"])
+
+    def test_unstable_pattern_direction_flip_is_rejected(self):
+        # First half all wins, second half all losses at close range - the
+        # stability gate should reject this even though the raw win rate
+        # (50%) might otherwise look plausible; nothing else clears the bar
+        # either, so it falls back.
+        for day in range(1, 7):
+            self._write_match(day, [kill_event(ME, RIVAL, distance_m=8)])
+        for day in range(7, 13):
+            self._write_match(day, [kill_event(RIVAL, ME, distance_m=8)])
+
+        result = compute_headline_number(ME, telemetry_dir=self.tmpdir.name)
+
+        self.assertNotEqual(result["stat_key"], "close_range_win_rate")
+
+    def test_knockdown_conversion_links_via_dbno_id(self):
+        # One knockdown resolved via a matching-dBNOId kill (converted),
+        # the rest resolved via revive (not converted) - exercises the
+        # kill-side of the dBNOId linkage, not just the revive-only path
+        # covered separately below. The single converting kill is placed
+        # on day 1 so it lands entirely in the first stability-check half,
+        # keeping kills-before-death's own reading unstable (excluded)
+        # rather than competing with this candidate.
+        events = [groggy_event(ME, RIVAL, dbno_id=1), kill_event(ME, RIVAL, distance_m=999, dbno_id=1)]
+        self._write_match(1, events)
+        for day in range(2, 13):
+            events = [groggy_event(ME, RIVAL, dbno_id=100 + day), revive_event(TEAMMATE, RIVAL)]
+            events[1]["dBNOId"] = 100 + day
+            self._write_match(day, events)
+
+        result = compute_headline_number(ME, telemetry_dir=self.tmpdir.name)
+
+        self.assertEqual(result["stat_key"], "knockdown_conversion_rate")
+        self.assertIn("1/12", result["headline"])
+
+    def test_knockdown_resolved_by_revive_counts_as_not_converted(self):
+        for day in range(1, 13):
+            events = [
+                groggy_event(ME, RIVAL, dbno_id=200 + day),
+                revive_event(TEAMMATE, RIVAL),
+            ]
+            events[1]["dBNOId"] = 200 + day
+            self._write_match(day, events)
+
+        result = compute_headline_number(ME, telemetry_dir=self.tmpdir.name)
+
+        # Every knockdown was saved by a revive - 0% conversion is a stable
+        # (if unflattering) pattern and should still be surfaced, not hidden.
+        self.assertEqual(result["stat_key"], "knockdown_conversion_rate")
+        self.assertIn("0%", result["headline"])
+
+    def test_revives_per_match_counted(self):
+        for day in range(1, 13):
+            self._write_match(day, [revive_event(ME, TEAMMATE), kill_event(RIVAL, ME, distance_m=500)])
+
+        result = compute_headline_number(ME, telemetry_dir=self.tmpdir.name)
+
+        self.assertEqual(result["stat_key"], "revives")
+        self.assertIn("1.0 revives", result["headline"])
+
+    def test_damage_excludes_self_and_bot_damage(self):
+        for day in range(1, 13):
+            self._write_match(day, [
+                damage_event(ME, RIVAL, 50),
+                damage_event(ME, ME, 20),
+                damage_event(ME, RIVAL, 30, victim_type="user_ai"),
+            ])
+
+        result = compute_headline_number(ME, telemetry_dir=self.tmpdir.name)
+
+        self.assertEqual(result["stat_key"], "damage")
+        self.assertIn("50 damage", result["headline"])
+
+    def test_highest_scoring_eligible_candidate_wins(self):
+        # A consistently one-sided close-range rate (0% win rate every
+        # match) should beat a damage signal that's eligible and stable
+        # but too noisy (wide swings match to match) to score as highly.
+        damage_values = [0, 300, 0, 280, 0, 260, 0, 290, 0, 270, 0, 300]
+        for day in range(1, 13):
+            events = [
+                kill_event(RIVAL, ME, distance_m=8),
+                damage_event(ME, RIVAL, damage_values[day - 1]),
+            ]
+            self._write_match(day, events)
+
+        result = compute_headline_number(ME, telemetry_dir=self.tmpdir.name)
+
+        self.assertEqual(result["stat_key"], "close_range_win_rate")
+
+    def test_states_sample_size_inline(self):
+        for day in range(1, 13):
+            self._write_match(day, [kill_event(ME, RIVAL, distance_m=8)])
+
+        result = compute_headline_number(ME, telemetry_dir=self.tmpdir.name)
+
+        self.assertIn(str(result["matches_analyzed"]), result["headline"])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_last_match_brief.py
+++ b/tests/test_last_match_brief.py
@@ -187,23 +187,46 @@ class TestFindLatestMatchForPlayer(unittest.TestCase):
             json.dump(events, f)
 
     def test_only_considers_matches_player_appears_in(self):
+        # Defensive check: even if a candidate ID turns out not to actually
+        # contain the player (shouldn't happen in practice, since
+        # candidate_match_ids comes from the player's own API data), it's
+        # still excluded rather than trusted blindly.
         self._write_match("with-me", "2026-01-01T00:00:00.000Z", ME)
         self._write_match("without-me", "2026-06-01T00:00:00.000Z", KILLER)
 
-        match_id, events = find_latest_match_for_player(ME, telemetry_dir=self.tmpdir.name)
+        match_id, events = find_latest_match_for_player(
+            ME, ["with-me", "without-me"], telemetry_dir=self.tmpdir.name
+        )
 
         self.assertEqual(match_id, "with-me")
+
+    def test_ignores_cached_matches_not_in_the_candidate_list(self):
+        self._write_match("mine", "2026-01-01T00:00:00.000Z", ME)
+        self._write_match("someone-elses-more-recent", "2026-06-01T00:00:00.000Z", KILLER)
+
+        match_id, events = find_latest_match_for_player(ME, ["mine"], telemetry_dir=self.tmpdir.name)
+
+        self.assertEqual(match_id, "mine")
+
+    def test_skips_candidate_matches_not_yet_cached(self):
+        self._write_match("cached", "2026-01-01T00:00:00.000Z", ME)
+
+        match_id, events = find_latest_match_for_player(
+            ME, ["cached", "not-cached-yet"], telemetry_dir=self.tmpdir.name
+        )
+
+        self.assertEqual(match_id, "cached")
 
     def test_picks_latest_among_matches_player_appears_in(self):
         self._write_match("older", "2026-01-01T00:00:00.000Z", ME)
         self._write_match("newer", "2026-03-01T00:00:00.000Z", ME)
 
-        match_id, events = find_latest_match_for_player(ME, telemetry_dir=self.tmpdir.name)
+        match_id, events = find_latest_match_for_player(ME, ["older", "newer"], telemetry_dir=self.tmpdir.name)
 
         self.assertEqual(match_id, "newer")
 
     def test_no_matches_returns_none(self):
-        match_id, events = find_latest_match_for_player(ME, telemetry_dir=self.tmpdir.name)
+        match_id, events = find_latest_match_for_player(ME, [], telemetry_dir=self.tmpdir.name)
 
         self.assertIsNone(match_id)
         self.assertIsNone(events)

--- a/tests/test_last_match_brief.py
+++ b/tests/test_last_match_brief.py
@@ -30,8 +30,11 @@ def match_end_entry(account_id, ranking):
     return {"character": {"accountId": account_id, "ranking": ranking}}
 
 
-def create_event(account_id, timestamp="2026-01-01T00:00:00.000Z"):
-    return {"_T": "LogPlayerCreate", "_D": timestamp, "character": {"accountId": account_id, "type": "user"}}
+def create_event(account_id, timestamp="2026-01-01T00:00:00.000Z", team_id=1, name=None):
+    character = {"accountId": account_id, "type": "user", "teamId": team_id}
+    if name:
+        character["name"] = name
+    return {"_T": "LogPlayerCreate", "_D": timestamp, "character": character}
 
 
 def kill_event(killer_id, killer_name, victim_id, weapon, distance_cm, timestamp, is_suicide=False):
@@ -94,6 +97,72 @@ class TestComputeLastMatchBrief(unittest.TestCase):
         brief = compute_last_match_brief(ME, "match-1", events)
 
         self.assertEqual(brief["most_used_weapon"], "AKM")
+
+
+class TestSquadStatusAtDeath(unittest.TestCase):
+
+    def test_none_when_player_survives_to_match_end(self):
+        events = [
+            match_start_event(),
+            create_event(ME, name="Me"),
+            create_event("account.mate", name="Mate"),
+            match_end_event([match_end_entry(ME, 1)]),
+        ]
+
+        brief = compute_last_match_brief(ME, "match-1", events)
+
+        self.assertIsNone(brief["squad_status"])
+
+    def test_none_when_no_other_teammates(self):
+        events = [
+            match_start_event(),
+            create_event(ME, name="Me"),
+            kill_event(KILLER, "Rival", ME, "WeapAUG_C", 2000.0, "2026-01-01T00:05:00.000Z"),
+            match_end_event([match_end_entry(ME, 30)]),
+        ]
+
+        brief = compute_last_match_brief(ME, "match-1", events)
+
+        self.assertIsNone(brief["squad_status"])
+
+    def test_classifies_each_teammate_relative_to_players_death(self):
+        # Player (ME) dies at 00:10:00. Teammates:
+        #  - "AliveMate" never dies -> still alive
+        #  - "SameFightMate" dies 20s before ME (inside the 30s window) -> same fight
+        #  - "EarlierMate" dies 5 minutes before ME -> unrelated, eliminated earlier
+        events = [
+            match_start_event(),
+            create_event(ME, name="Me"),
+            create_event("account.alive", name="AliveMate"),
+            create_event("account.samefight", name="SameFightMate"),
+            create_event("account.earlier", name="EarlierMate"),
+            kill_event(KILLER, "Rival", "account.earlier", "WeapAUG_C", 1000.0, "2026-01-01T00:05:00.000Z"),
+            kill_event(KILLER, "Rival", "account.samefight", "WeapAUG_C", 1000.0, "2026-01-01T00:09:40.000Z"),
+            kill_event(KILLER, "Rival", ME, "WeapAUG_C", 2000.0, "2026-01-01T00:10:00.000Z"),
+            match_end_event([match_end_entry(ME, 5)]),
+        ]
+
+        brief = compute_last_match_brief(ME, "match-1", events)
+
+        by_name = {s["name"]: s for s in brief["squad_status"]}
+        self.assertEqual(by_name["AliveMate"]["status"], "alive")
+        self.assertEqual(by_name["SameFightMate"]["status"], "same_engagement")
+        self.assertEqual(by_name["SameFightMate"]["seconds_before"], 20.0)
+        self.assertEqual(by_name["EarlierMate"]["status"], "eliminated_earlier")
+        self.assertEqual(by_name["EarlierMate"]["seconds_before"], 300.0)
+
+    def test_ignores_teammates_on_a_different_team(self):
+        events = [
+            match_start_event(),
+            create_event(ME, name="Me", team_id=1),
+            create_event("account.other", name="NotMyTeammate", team_id=2),
+            kill_event(KILLER, "Rival", ME, "WeapAUG_C", 2000.0, "2026-01-01T00:05:00.000Z"),
+            match_end_event([match_end_entry(ME, 20)]),
+        ]
+
+        brief = compute_last_match_brief(ME, "match-1", events)
+
+        self.assertIsNone(brief["squad_status"])
 
 
 class TestPlayerPresentInMatch(unittest.TestCase):

--- a/tests/test_match_scope.py
+++ b/tests/test_match_scope.py
@@ -18,14 +18,7 @@ from utils.match_scope import (
     select_scoped_match_ids,
 )
 
-ME = "account.me"
-RIVAL = "account.rival"
-
 NOW = datetime(2026, 7, 25, tzinfo=timezone.utc)
-
-
-def create_event(account_id):
-    return {"_T": "LogPlayerCreate", "character": {"accountId": account_id, "type": "user"}}
 
 
 def match_start(days_ago):
@@ -42,24 +35,35 @@ class TestSelectScopedMatchIds(unittest.TestCase):
     def setUp(self):
         self.tmpdir = tempfile.TemporaryDirectory()
         self.addCleanup(self.tmpdir.cleanup)
+        self.candidate_match_ids = []
 
-    def _write_match(self, match_id, days_ago, present=True):
+    def _write_match(self, match_id, days_ago, is_candidate=True):
+        # is_candidate=False simulates a telemetry file that's cached (e.g.
+        # from looking up a different player) but doesn't belong to this
+        # player's own known match list - select_scoped_match_ids should
+        # never consider it, since it only ever looks at candidate_match_ids.
         events = [match_start(days_ago)]
-        if present:
-            events.append(create_event(ME))
-        else:
-            events.append(create_event(RIVAL))
         path = os.path.join(self.tmpdir.name, f"{match_id}-telemetry.json")
         with open(path, "w") as f:
             json.dump(events, f)
+        if is_candidate:
+            self.candidate_match_ids.append(match_id)
 
-    def test_excludes_matches_the_player_never_played(self):
-        self._write_match("mine", days_ago=1, present=True)
-        self._write_match("unrelated", days_ago=1, present=False)
+    def test_ignores_cached_matches_not_in_the_candidate_list(self):
+        self._write_match("mine", days_ago=1, is_candidate=True)
+        self._write_match("someone-elses", days_ago=1, is_candidate=False)
 
-        result = select_scoped_match_ids(ME, telemetry_dir=self.tmpdir.name, now=NOW)
+        result = select_scoped_match_ids(self.candidate_match_ids, telemetry_dir=self.tmpdir.name, now=NOW)
 
         self.assertEqual(result, ["mine"])
+
+    def test_skips_candidate_matches_not_yet_cached(self):
+        self._write_match("cached", days_ago=1, is_candidate=True)
+        self.candidate_match_ids.append("not-cached-yet")
+
+        result = select_scoped_match_ids(self.candidate_match_ids, telemetry_dir=self.tmpdir.name, now=NOW)
+
+        self.assertEqual(result, ["cached"])
 
     def test_returns_all_available_when_under_cap(self):
         """Fewer matches exist than the cap - widening exhausts the full
@@ -69,7 +73,7 @@ class TestSelectScopedMatchIds(unittest.TestCase):
         for i in range(count):
             self._write_match(f"recent-{i}", days_ago=5)
 
-        result = select_scoped_match_ids(ME, telemetry_dir=self.tmpdir.name, now=NOW)
+        result = select_scoped_match_ids(self.candidate_match_ids, telemetry_dir=self.tmpdir.name, now=NOW)
 
         self.assertEqual(len(result), count)
 
@@ -78,7 +82,7 @@ class TestSelectScopedMatchIds(unittest.TestCase):
         for i in range(count):
             self._write_match(f"recent-{i}", days_ago=5)
 
-        result = select_scoped_match_ids(ME, telemetry_dir=self.tmpdir.name, now=NOW)
+        result = select_scoped_match_ids(self.candidate_match_ids, telemetry_dir=self.tmpdir.name, now=NOW)
 
         self.assertEqual(len(result), MAX_MATCHES)
 
@@ -87,7 +91,7 @@ class TestSelectScopedMatchIds(unittest.TestCase):
         for i in range(count):
             self._write_match(f"match-{i}", days_ago=count - i)  # highest index is most recent (1 day ago)
 
-        result = select_scoped_match_ids(ME, telemetry_dir=self.tmpdir.name, now=NOW)
+        result = select_scoped_match_ids(self.candidate_match_ids, telemetry_dir=self.tmpdir.name, now=NOW)
 
         self.assertIn(f"match-{count - 1}", result)
         self.assertNotIn("match-0", result)
@@ -100,7 +104,7 @@ class TestSelectScopedMatchIds(unittest.TestCase):
         for i in range(within_60):
             self._write_match(f"within-60-{i}", days_ago=INITIAL_WINDOW_DAYS + WINDOW_INCREMENT_DAYS - 5)
 
-        result = select_scoped_match_ids(ME, telemetry_dir=self.tmpdir.name, now=NOW)
+        result = select_scoped_match_ids(self.candidate_match_ids, telemetry_dir=self.tmpdir.name, now=NOW)
 
         self.assertEqual(len(result), MAX_MATCHES)
 
@@ -112,7 +116,7 @@ class TestSelectScopedMatchIds(unittest.TestCase):
         for i in range(within_60):
             self._write_match(f"within-60-{i}", days_ago=INITIAL_WINDOW_DAYS + WINDOW_INCREMENT_DAYS - 5)
 
-        result = select_scoped_match_ids(ME, telemetry_dir=self.tmpdir.name, now=NOW)
+        result = select_scoped_match_ids(self.candidate_match_ids, telemetry_dir=self.tmpdir.name, now=NOW)
 
         self.assertEqual(len(result), within_30 + within_60)
 
@@ -120,19 +124,19 @@ class TestSelectScopedMatchIds(unittest.TestCase):
         for i in range(10):
             self._write_match(f"old-{i}", days_ago=MAX_WINDOW_DAYS - 5)
 
-        result = select_scoped_match_ids(ME, telemetry_dir=self.tmpdir.name, now=NOW)
+        result = select_scoped_match_ids(self.candidate_match_ids, telemetry_dir=self.tmpdir.name, now=NOW)
 
         self.assertEqual(len(result), 10)
 
     def test_matches_beyond_max_window_excluded_even_if_sparse(self):
         self._write_match("too-old", days_ago=MAX_WINDOW_DAYS + 1)
 
-        result = select_scoped_match_ids(ME, telemetry_dir=self.tmpdir.name, now=NOW)
+        result = select_scoped_match_ids(self.candidate_match_ids, telemetry_dir=self.tmpdir.name, now=NOW)
 
         self.assertEqual(result, [])
 
-    def test_empty_when_no_matches_cached(self):
-        result = select_scoped_match_ids(ME, telemetry_dir=self.tmpdir.name, now=NOW)
+    def test_empty_when_no_candidate_matches(self):
+        result = select_scoped_match_ids([], telemetry_dir=self.tmpdir.name, now=NOW)
 
         self.assertEqual(result, [])
 

--- a/tests/test_squad_read.py
+++ b/tests/test_squad_read.py
@@ -1,0 +1,196 @@
+##########
+# Unit Test for Squad Read (synergy line + "opens first" bolstering)
+# from root of project: `python -m unittest discover tests`
+##########
+
+import json
+import os
+import tempfile
+import unittest
+
+from utils.squad_read import compute_synergy_line, compute_engagement_lead, compute_squad_read, BOLSTER_WINDOW
+
+ME = "account.me"
+MATE = "account.mate"
+RIVAL = "account.rival"
+MATE_NAME = "DanucD"
+
+
+def match_start(day):
+    return {"_T": "LogMatchStart", "_D": f"2026-07-{day:02d}T00:00:00.000Z"}
+
+
+def create_event(account_id):
+    return {"_T": "LogPlayerCreate", "character": {"accountId": account_id, "type": "user"}}
+
+
+def damage_event(attacker_id, victim_id, seconds_after_start):
+    return {
+        "_T": "LogPlayerTakeDamage",
+        "attacker": {"accountId": attacker_id, "type": "user"},
+        "victim": {"accountId": victim_id, "type": "user"},
+        "_D": f"2026-07-01T00:{seconds_after_start // 60:02d}:{seconds_after_start % 60:02d}.000Z",
+    }
+
+
+class TestComputeSynergyLine(unittest.TestCase):
+
+    def test_missing_data_returns_none(self):
+        self.assertIsNone(compute_synergy_line(None, "Aggressive", "Mate", "Close-Range", "Aggressive"))
+        self.assertIsNone(compute_synergy_line("Close-Range", None, "Mate", "Close-Range", "Aggressive"))
+
+    def test_cases(self):
+        cases = [
+            (
+                "identical_aggressive",
+                ("Close-Range", "Aggressive", "Close-Range", "Aggressive"),
+                "matching aggressive playstyles",
+            ),
+            (
+                "identical_passive",
+                ("Long-Range", "Passive", "Long-Range", "Passive"),
+                "matching passive playstyles",
+            ),
+            (
+                "identical_balanced",
+                ("Mid-Range", "Balanced", "Mid-Range", "Balanced"),
+                "closely matched playstyles",
+            ),
+            (
+                "same_temperament_self_closer",
+                ("Close-Range", "Balanced", "Long-Range", "Balanced"),
+                "you get into the fight up close",
+            ),
+            (
+                "same_temperament_teammate_closer",
+                ("Long-Range", "Balanced", "Close-Range", "Balanced"),
+                f"{MATE_NAME} gets into the fight up close",
+            ),
+            (
+                "same_range_self_faster",
+                ("Mid-Range", "Aggressive", "Mid-Range", "Balanced"),
+                "you tend to commit sooner",
+            ),
+            (
+                "same_range_teammate_faster",
+                ("Mid-Range", "Balanced", "Mid-Range", "Aggressive"),
+                f"{MATE_NAME} tends to commit sooner",
+            ),
+            (
+                "aligned_self_pushes",
+                ("Close-Range", "Aggressive", "Long-Range", "Passive"),
+                "classic push-and-cover: you push in",
+            ),
+            (
+                "aligned_teammate_pushes",
+                ("Long-Range", "Passive", "Close-Range", "Aggressive"),
+                f"classic push-and-cover: {MATE_NAME} pushes in",
+            ),
+            (
+                "misaligned",
+                ("Long-Range", "Aggressive", "Close-Range", "Passive"),
+                "an unusual mix",
+            ),
+        ]
+        for name, (self_range, self_temp, mate_range, mate_temp), expected_substring in cases:
+            with self.subTest(case=name):
+                result = compute_synergy_line(self_range, self_temp, MATE_NAME, mate_range, mate_temp)
+                self.assertIn(expected_substring, result)
+
+
+class TestComputeEngagementLead(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+        self.match_ids = []
+
+    def _write_shared_match(self, day, self_contact_seconds, mate_contact_seconds):
+        events = [
+            match_start(day),
+            create_event(ME),
+            create_event(MATE),
+            damage_event(ME, RIVAL, self_contact_seconds),
+            damage_event(MATE, RIVAL, mate_contact_seconds),
+        ]
+        match_id = f"match-{day}"
+        path = os.path.join(self.tmpdir.name, f"{match_id}-telemetry.json")
+        with open(path, "w") as f:
+            json.dump(events, f)
+        self.match_ids.append(match_id)
+
+    def test_none_below_bolster_window(self):
+        for day in range(1, BOLSTER_WINDOW - 1):
+            self._write_shared_match(day, self_contact_seconds=10, mate_contact_seconds=50)
+
+        result = compute_engagement_lead(ME, MATE, MATE_NAME, self.match_ids, telemetry_dir=self.tmpdir.name)
+
+        self.assertIsNone(result)
+
+    def test_none_when_no_leader_clears_threshold(self):
+        # 4-4 split across 8 matches - neither reaches the 5-of-8 bar.
+        for day in range(1, 5):
+            self._write_shared_match(day, self_contact_seconds=10, mate_contact_seconds=50)
+        for day in range(5, 9):
+            self._write_shared_match(day, self_contact_seconds=50, mate_contact_seconds=10)
+
+        result = compute_engagement_lead(ME, MATE, MATE_NAME, self.match_ids, telemetry_dir=self.tmpdir.name)
+
+        self.assertIsNone(result)
+
+    def test_teammate_opens_first_bolstered(self):
+        for day in range(1, 7):
+            self._write_shared_match(day, self_contact_seconds=100, mate_contact_seconds=10)
+        for day in range(7, 9):
+            self._write_shared_match(day, self_contact_seconds=10, mate_contact_seconds=100)
+
+        result = compute_engagement_lead(ME, MATE, MATE_NAME, self.match_ids, telemetry_dir=self.tmpdir.name)
+
+        self.assertIn(MATE_NAME, result)
+        self.assertIn("6 of your last 8", result)
+
+    def test_self_opens_first_bolstered(self):
+        for day in range(1, 6):
+            self._write_shared_match(day, self_contact_seconds=10, mate_contact_seconds=100)
+        for day in range(6, 9):
+            self._write_shared_match(day, self_contact_seconds=100, mate_contact_seconds=10)
+
+        result = compute_engagement_lead(ME, MATE, MATE_NAME, self.match_ids, telemetry_dir=self.tmpdir.name)
+
+        self.assertIn("you've opened", result)
+        self.assertIn("5 of your last 8", result)
+
+    def test_uses_most_recent_window_only(self):
+        # 10 shared matches total: oldest 2 favor ME, most recent 8 favor MATE 5-3.
+        # Only the most recent 8 should count, so MATE should be the bolstered leader.
+        for day in range(1, 3):
+            self._write_shared_match(day, self_contact_seconds=10, mate_contact_seconds=100)
+        for day in range(3, 8):
+            self._write_shared_match(day, self_contact_seconds=100, mate_contact_seconds=10)
+        for day in range(8, 11):
+            self._write_shared_match(day, self_contact_seconds=10, mate_contact_seconds=100)
+
+        result = compute_engagement_lead(ME, MATE, MATE_NAME, self.match_ids, telemetry_dir=self.tmpdir.name)
+
+        self.assertIn(MATE_NAME, result)
+
+
+class TestComputeSquadRead(unittest.TestCase):
+
+    def test_combines_synergy_and_shared_match_intersection(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self_archetype = {"range": {"range_bucket": "Close-Range"}, "temperament": "Aggressive"}
+            teammate_archetype = {"range": {"range_bucket": "Long-Range"}, "temperament": "Passive"}
+
+            result = compute_squad_read(
+                ME, self_archetype, {"match-a", "match-b", "match-c"},
+                MATE, MATE_NAME, teammate_archetype, {"match-b", "match-c", "match-d"},
+                telemetry_dir=tmpdir,
+            )
+
+            self.assertIn("classic push-and-cover", result["synergy_line"])
+            self.assertEqual(result["shared_matches_analyzed"], 2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_squad_roster.py
+++ b/tests/test_squad_roster.py
@@ -1,0 +1,172 @@
+##########
+# Unit Test for Squad Roster (coverage/distribution summary, N players)
+# from root of project: `python -m unittest discover tests`
+##########
+
+import json
+import os
+import tempfile
+import unittest
+
+from utils.squad_roster import compute_squad_coverage_summary, compute_best_engagement_lead, compute_squad_roster
+
+ME = "account.me"
+MATE_A = "account.a"
+MATE_B = "account.b"
+MATE_C = "account.c"
+RIVAL = "account.rival"
+
+
+def archetype(range_bucket, temperament, tempo_tag="Quick-Gear Striker"):
+    return {
+        "range": {"range_bucket": range_bucket},
+        "temperament": temperament,
+        "tempo": {"tempo_tag": tempo_tag},
+        "short_tag": f"{range_bucket}/{temperament}" if range_bucket and temperament else None,
+    }
+
+
+def member(name, account_id, range_bucket, temperament, match_ids=None):
+    return {
+        "name": name,
+        "account_id": account_id,
+        "archetype": archetype(range_bucket, temperament),
+        "match_ids": match_ids or [],
+    }
+
+
+class TestComputeSquadCoverageSummary(unittest.TestCase):
+
+    def test_none_when_fewer_than_two_profiled(self):
+        members = [member("You", ME, "Close-Range", "Aggressive")]
+        self.assertIsNone(compute_squad_coverage_summary(members))
+
+    def test_none_when_a_member_lacks_data(self):
+        members = [
+            member("You", ME, "Close-Range", "Aggressive"),
+            member("Mate", MATE_A, None, None),
+        ]
+        self.assertIsNone(compute_squad_coverage_summary(members))
+
+    def test_balanced_squad_with_full_coverage_and_role_callouts(self):
+        members = [
+            member("You", ME, "Long-Range", "Passive"),
+            member("DanucD", MATE_A, "Close-Range", "Aggressive"),
+            member("Vacency", MATE_B, "Mid-Range", "Balanced"),
+        ]
+        result = compute_squad_coverage_summary(members)
+
+        self.assertIn("Balanced squad", result)
+        self.assertIn("you (support anchor)", result)
+        self.assertIn("DanucD (entry fragger)", result)
+        self.assertIn("Vacency cover", result)
+        self.assertIn("No overlapping blind spots.", result)
+
+    def test_all_aggressive_squad(self):
+        members = [
+            member("You", ME, "Close-Range", "Aggressive"),
+            member("Mate", MATE_A, "Close-Range", "Aggressive"),
+        ]
+        result = compute_squad_coverage_summary(members)
+
+        self.assertIn("All-Aggressive squad", result)
+
+    def test_flags_missing_range_coverage(self):
+        members = [
+            member("You", ME, "Close-Range", "Aggressive"),
+            member("Mate", MATE_A, "Mid-Range", "Balanced"),
+        ]
+        result = compute_squad_coverage_summary(members)
+
+        self.assertIn("No one covers long-range", result)
+
+    def test_leftover_balanced_members_grouped_by_range_span(self):
+        members = [
+            member("You", ME, "Close-Range", "Balanced"),
+            member("Mate", MATE_A, "Long-Range", "Balanced"),
+        ]
+        result = compute_squad_coverage_summary(members)
+
+        self.assertIn("you and Mate cover close-to-long", result)
+
+
+class TestComputeBestEngagementLead(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+
+    def _write_match(self, match_id, day, contact_by_account):
+        events = [
+            {"_T": "LogMatchStart", "_D": f"2026-07-{day:02d}T00:00:00.000Z"},
+        ]
+        for account_id in contact_by_account:
+            events.append({"_T": "LogPlayerCreate", "character": {"accountId": account_id, "type": "user"}})
+        for account_id, seconds in contact_by_account.items():
+            events.append({
+                "_T": "LogPlayerTakeDamage",
+                "attacker": {"accountId": account_id, "type": "user"},
+                "victim": {"accountId": RIVAL, "type": "user"},
+                "_D": f"2026-07-{day:02d}T00:{seconds // 60:02d}:{seconds % 60:02d}.000Z",
+            })
+        path = os.path.join(self.tmpdir.name, f"{match_id}-telemetry.json")
+        with open(path, "w") as f:
+            json.dump(events, f)
+
+    def test_picks_the_strongest_teammate_comparison(self):
+        match_ids_a = []
+        match_ids_b = []
+        # vs MATE_A: 5-of-8 leans "you" opened first
+        for day in range(1, 6):
+            mid = f"a-{day}"
+            self._write_match(mid, day, {ME: 10, MATE_A: 100})
+            match_ids_a.append(mid)
+        for day in range(6, 9):
+            mid = f"a-{day}"
+            self._write_match(mid, day, {ME: 100, MATE_A: 10})
+            match_ids_a.append(mid)
+
+        # vs MATE_B: 8-of-8 - a stronger, more decisive pattern
+        for day in range(1, 9):
+            mid = f"b-{day}"
+            self._write_match(mid, day, {ME: 10, MATE_B: 100})
+            match_ids_b.append(mid)
+
+        members = [
+            member("You", ME, "Mid-Range", "Balanced"),
+            member("MateA", MATE_A, "Mid-Range", "Balanced", match_ids=match_ids_a),
+            member("MateB", MATE_B, "Mid-Range", "Balanced", match_ids=match_ids_b),
+        ]
+        members[0]["match_ids"] = match_ids_a + match_ids_b
+
+        result = compute_best_engagement_lead(members, telemetry_dir=self.tmpdir.name)
+
+        self.assertIn("you've opened", result)
+        self.assertIn("8 of your last 8", result)
+
+    def test_none_when_no_teammate_clears_the_bar(self):
+        members = [
+            member("You", ME, "Mid-Range", "Balanced", match_ids=["m1"]),
+            member("Mate", MATE_A, "Mid-Range", "Balanced", match_ids=["m1"]),
+        ]
+        result = compute_best_engagement_lead(members, telemetry_dir=self.tmpdir.name)
+        self.assertIsNone(result)
+
+
+class TestComputeSquadRoster(unittest.TestCase):
+
+    def test_roster_rows_include_you_and_teammates(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            members = [
+                member("You", ME, "Long-Range", "Passive"),
+                member("DanucD", MATE_A, "Close-Range", "Aggressive"),
+            ]
+            result = compute_squad_roster(members, telemetry_dir=tmpdir)
+
+            names = [row["name"] for row in result["roster_rows"]]
+            self.assertEqual(names, ["You", "DanucD"])
+            self.assertIsNotNone(result["coverage_summary"])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/utils/archetype_tag.py
+++ b/utils/archetype_tag.py
@@ -1,7 +1,6 @@
 # ==============================
 # utils/archetype_tag.py
 # ==============================
-from utils.match_scope import select_scoped_match_ids
 from utils.range_signal import compute_range_signal
 from utils.tempo_signal import compute_tempo_signal
 from utils.weapon_signature import compute_weapon_signature
@@ -21,17 +20,14 @@ TEMPO_TO_TEMPERAMENT = {
 }
 
 
-def compute_archetype_tag(account_id, telemetry_dir=TELEMETRY_DIR, match_ids=None):
+def compute_archetype_tag(account_id, match_ids, telemetry_dir=TELEMETRY_DIR):
     """Combine tempo, range, and weapon-signature into the Archetype Tag.
 
-    Resolves the player's scoped match set once (see match_scope.py) and
-    reuses it across all three signals, rather than each one independently
-    rescanning the full shared telemetry cache.
+    match_ids is the player's scoped match set (see match_scope.py),
+    resolved once by the caller and reused across all three signals here
+    rather than each one independently rescanning the telemetry cache.
     """
-    if match_ids is None:
-        match_ids = set(select_scoped_match_ids(account_id, telemetry_dir=telemetry_dir))
-    else:
-        match_ids = set(match_ids)
+    match_ids = set(match_ids)
 
     tempo = compute_tempo_signal(account_id, match_ids=match_ids, telemetry_dir=telemetry_dir)
     range_signal = compute_range_signal(account_id, match_ids=match_ids, telemetry_dir=telemetry_dir)

--- a/utils/archetype_tag.py
+++ b/utils/archetype_tag.py
@@ -41,6 +41,7 @@ def compute_archetype_tag(account_id, match_ids, telemetry_dir=TELEMETRY_DIR):
         "tempo": tempo,
         "range": range_signal,
         "weapon": weapon,
+        "temperament": temperament,
         "short_tag": short_tag,
         "matches_analyzed": len(match_ids),
     }

--- a/utils/display_archetype_tag.py
+++ b/utils/display_archetype_tag.py
@@ -14,7 +14,7 @@ def render_archetype_tag(archetype):
 
     tempo_line = tempo["tempo_tag"] or "Not enough data"
     if tempo["tempo_tag"]:
-        tempo_line += f"  ({tempo['matches_with_contact']}/{tempo['matches_analyzed']} matches with early contact)"
+        tempo_line += f"  ({tempo['matches_with_contact']}/{tempo['matches_analyzed']} matches with contact)"
     print(f"Tempo  : {tempo_line}")
 
     range_bucket = range_signal["range_bucket"]

--- a/utils/display_headline_number.py
+++ b/utils/display_headline_number.py
@@ -1,0 +1,10 @@
+# ==============================
+# utils/display_headline_number.py
+# ==============================
+
+
+def render_headline_number(headline):
+    print("=============================")
+    print("📊 The Number That Matters")
+    print("=============================")
+    print(headline["headline"])

--- a/utils/display_last_match_brief.py
+++ b/utils/display_last_match_brief.py
@@ -26,6 +26,17 @@ def render_last_match_brief(playername, brief, played_with_you=None):
     else:
         print("Died To    : Survived to match end")
 
+    squad_status = brief.get("squad_status")
+    if squad_status:
+        print("Squad Status at the time:")
+        for teammate in squad_status:
+            if teammate["status"] == "alive":
+                print(f"  {teammate['name']}: still alive")
+            elif teammate["status"] == "same_engagement":
+                print(f"  {teammate['name']}: went down {teammate['seconds_before']}s earlier, same fight")
+            else:
+                print(f"  {teammate['name']}: already eliminated earlier, unrelated to this fight")
+
     if played_with_you is not None:
         print(f"In your last shared match: {'Yes' if played_with_you else 'No'}")
     print()

--- a/utils/display_squad_read.py
+++ b/utils/display_squad_read.py
@@ -1,0 +1,18 @@
+# ==============================
+# utils/display_squad_read.py
+# ==============================
+
+
+def render_squad_read(squad_read):
+    print("=============================")
+    print("🤝 Squad Read")
+    print("=============================")
+
+    if squad_read["synergy_line"]:
+        print(squad_read["synergy_line"])
+    else:
+        print("Not enough data yet for a synergy read.")
+
+    if squad_read["bolstered_line"]:
+        print()
+        print(squad_read["bolstered_line"])

--- a/utils/display_squad_roster.py
+++ b/utils/display_squad_roster.py
@@ -1,0 +1,40 @@
+# ==============================
+# utils/display_squad_roster.py
+# ==============================
+from utils.display_archetype_tag import render_archetype_tag
+from utils.display_headline_number import render_headline_number
+
+NAME_WIDTH = 14
+TAG_WIDTH = 24
+
+
+def render_squad_roster(roster):
+    print("=============================================")
+    print("🎮 SQUAD ROSTER - At a Glance")
+    print("=============================================")
+
+    for row in roster["roster_rows"]:
+        tempo = row["tempo_tag"] or "Not enough data"
+        tag = row["short_tag"] or "-"
+        print(f"  {row['name'].ljust(NAME_WIDTH)}{tempo.ljust(TAG_WIDTH)}{tag}")
+
+    print()
+    print("🤝 Squad Read:", roster["coverage_summary"] or "Not enough data yet for a squad read.")
+
+    if roster["bolstered_line"]:
+        print()
+        print(roster["bolstered_line"])
+
+    print("=============================================")
+
+
+def render_full_squad_cards(members, archetypes, headlines):
+    """Full per-player 5-slot cards after the roster summary - members[0]
+    is "you", already shown in the roster table above so only teammates
+    get a full card here (matches the design doc's mockup)."""
+    for member in members[1:]:
+        name = member["name"]
+        print()
+        print(f"--- {name} ---")
+        render_archetype_tag(archetypes[name])
+        render_headline_number(headlines[name])

--- a/utils/display_stats_by_mode.py
+++ b/utils/display_stats_by_mode.py
@@ -68,7 +68,7 @@ def print_static_banner(playername=None):
 
 
 def format_number(val, key=None):
-    if key and "TimeSurvived" in key:
+    if key and "timesurvived" in key.lower():
         minutes = int(val) // 60
         return f"{minutes:,}"
     if isinstance(val, (int, float)):

--- a/utils/headline_number.py
+++ b/utils/headline_number.py
@@ -1,0 +1,324 @@
+# ==============================
+# utils/headline_number.py
+# ==============================
+"""
+Headline Number: one differentiating, confidence-gated "so-what" stat,
+programmatically chosen from a fixed pool of PEPS+-grounded candidate
+templates (Firepower, Finishing, Combat Distance, and a team-support
+read via revives). No LLM involved - see docs/design/storyboard-profile.
+md's "Headline Number: how it's chosen" section for the full spec this
+implements.
+"""
+import glob
+import json
+import math
+import os
+import statistics
+from datetime import datetime
+
+from utils.last_match_brief import player_present_in_match
+from utils.range_signal import CLOSE_RANGE_MAX_METERS
+
+TELEMETRY_DIR = "match-telemetry"
+
+# Matches the MIN_*_FOR_SIGNAL threshold used across tempo/range/weapon
+# signals (Epstein aggregation principle / Spearman-Brown, ~8+ occasions
+# for a meaningfully reliable behavioral read) - a candidate needs at
+# least this many matches of underlying data to be eligible at all.
+MIN_MATCHES_FOR_CANDIDATE = 8
+
+# Stability gate: split a candidate's readings into chronological halves
+# and require both halves' deviation from the neutral reference to point
+# the same direction, with neither half's deviation dwarfing the other's
+# (guards against a pattern being carried entirely by one hot streak).
+MIN_HALF_STABILITY_RATIO = 0.25
+
+
+def _load_telemetry_files(match_ids=None, telemetry_dir=TELEMETRY_DIR):
+    for path in glob.glob(os.path.join(telemetry_dir, "*-telemetry.json")):
+        match_id = os.path.basename(path).replace("-telemetry.json", "")
+        if match_ids is not None and match_id not in match_ids:
+            continue
+        with open(path, "r") as f:
+            yield json.load(f)
+
+
+def _parse_timestamp(value):
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _is_real_kill(event, account_id):
+    if event.get("_T") != "LogPlayerKillV2" or event.get("isSuicide"):
+        return False
+    killer = event.get("killer") or {}
+    victim = event.get("victim") or {}
+    return (
+        killer.get("accountId") == account_id and killer.get("type") == "user"
+        and victim.get("type") == "user" and victim.get("accountId") != account_id
+    )
+
+
+def _is_real_death(event, account_id):
+    if event.get("_T") != "LogPlayerKillV2" or event.get("isSuicide"):
+        return False
+    killer = event.get("killer") or {}
+    victim = event.get("victim") or {}
+    return (
+        victim.get("accountId") == account_id and killer.get("type") == "user"
+        and killer.get("accountId") != account_id
+    )
+
+
+def _extract_match_readings(account_id, events):
+    """Pull every candidate's readings out of one match in a single pass.
+
+    Returns per-match magnitude readings (kills-before-death, revives,
+    damage) plus per-fight/per-knockdown binary readings (close-range
+    win, knockdown conversion), all tagged with the match start time so
+    they can be pooled across matches and split chronologically later.
+    """
+    if not player_present_in_match(account_id, events):
+        return None
+
+    start_event = next((e for e in events if e.get("_T") == "LogMatchStart"), None)
+    if not start_event or not start_event.get("_D"):
+        return None
+    match_start = _parse_timestamp(start_event["_D"])
+
+    kills_before_death = 0
+    died = False
+    revives = 0
+    damage = 0
+    close_range_fights = []
+    groggy_ids = {}
+    resolved_conversions = []
+
+    for event in events:
+        event_type = event.get("_T")
+
+        if _is_real_kill(event, account_id):
+            if not died:
+                kills_before_death += 1
+            distance_m = (event.get("killerDamageInfo") or {}).get("distance", 0) / 100
+            if distance_m <= CLOSE_RANGE_MAX_METERS:
+                close_range_fights.append(1)
+
+        elif _is_real_death(event, account_id):
+            died = True
+            distance_m = (event.get("killerDamageInfo") or {}).get("distance", 0) / 100
+            if distance_m <= CLOSE_RANGE_MAX_METERS:
+                close_range_fights.append(0)
+
+        elif event_type == "LogPlayerRevive":
+            if (event.get("reviver") or {}).get("accountId") == account_id:
+                revives += 1
+
+        elif event_type == "LogPlayerTakeDamage":
+            attacker = event.get("attacker") or {}
+            victim = event.get("victim") or {}
+            if attacker.get("accountId") == account_id and attacker.get("type") == "user" \
+                    and victim.get("type") == "user" and victim.get("accountId") != account_id:
+                damage += event.get("damage", 0)
+
+        elif event_type == "LogPlayerMakeGroggy":
+            attacker = event.get("attacker") or {}
+            victim = event.get("victim") or {}
+            dbno_id = event.get("dBNOId")
+            if attacker.get("accountId") == account_id and attacker.get("type") == "user" \
+                    and victim.get("type") == "user" and dbno_id is not None:
+                groggy_ids[dbno_id] = None
+
+    # Resolve each knockdown this player caused: did it end in a kill
+    # (converted) or a revive (saved)? Unresolved knockdowns (neither
+    # happened before the match ended, e.g. disconnect) aren't counted.
+    if groggy_ids:
+        for event in events:
+            dbno_id = event.get("dBNOId")
+            if dbno_id not in groggy_ids or groggy_ids[dbno_id] is not None:
+                continue
+            if event.get("_T") == "LogPlayerKillV2" and not event.get("isSuicide"):
+                groggy_ids[dbno_id] = 1
+            elif event.get("_T") == "LogPlayerRevive":
+                groggy_ids[dbno_id] = 0
+        resolved_conversions = [v for v in groggy_ids.values() if v is not None]
+
+    return {
+        "match_start": match_start,
+        "kills_before_death": kills_before_death,
+        "revives": revives,
+        "damage": damage,
+        "close_range_fights": close_range_fights,
+        "knockdown_conversions": resolved_conversions,
+    }
+
+
+def _is_stable(ordered_values, neutral_reference):
+    if len(ordered_values) < 2:
+        return False
+    midpoint = len(ordered_values) // 2
+    first_half, second_half = ordered_values[:midpoint], ordered_values[midpoint:]
+    if not first_half or not second_half:
+        return False
+
+    deviation_1 = statistics.mean(first_half) - neutral_reference
+    deviation_2 = statistics.mean(second_half) - neutral_reference
+    if deviation_1 == 0 or deviation_2 == 0:
+        return False
+    if (deviation_1 > 0) != (deviation_2 > 0):
+        return False
+
+    ratio = min(abs(deviation_1), abs(deviation_2)) / max(abs(deviation_1), abs(deviation_2))
+    return ratio >= MIN_HALF_STABILITY_RATIO
+
+
+def _score_rate(ordered_values):
+    """One-sample z-test for a proportion against a neutral 50/50 split.
+
+    Standard test for "is this rate different from chance" - uses the
+    fixed null-hypothesis variance p(1-p) at p=0.5 rather than the sample's
+    own variance, so a rate that happens to be perfectly consistent (every
+    reading the same) never divides by zero; the score just keeps growing
+    with sample size the way a real proportion test would.
+    """
+    n = len(ordered_values)
+    p_hat = statistics.mean(ordered_values)
+    standard_error = math.sqrt(0.25 / n)
+    return abs(p_hat - 0.5) / standard_error
+
+
+def _score_magnitude(ordered_values):
+    """One-sample t-statistic for a count/sum stat against a neutral zero.
+
+    Self-relative by construction (no external population dataset) -
+    rewards a candidate for being both large and consistent match to
+    match, since a wide spread inflates the standard error and drags the
+    score down even when the mean looks impressive. A sample with zero
+    observed variance (every match identical) gives no basis to estimate
+    spread at all - rather than guess at a distributional assumption
+    (which would let large-magnitude stats like damage score arbitrarily
+    high just for being suspiciously constant), score it 0 and defer to
+    a candidate with genuine measurable spread.
+    """
+    n = len(ordered_values)
+    mean = statistics.mean(ordered_values)
+    variance = statistics.variance(ordered_values) if n > 1 else 0
+    if variance == 0:
+        return 0.0
+    standard_error = math.sqrt(variance / n)
+    return mean / standard_error
+
+
+def compute_headline_number(account_id, match_ids=None, telemetry_dir=TELEMETRY_DIR):
+    """Pick the single most differentiating, confidence-gated stat.
+
+    Evaluates a fixed pool of candidates, keeps only those with enough
+    underlying matches and a directionally stable pattern, and surfaces
+    whichever eligible candidate scores highest. Falls back to a plain
+    kill count if nothing clears the bar, rather than force a shaky
+    "notable" stat onto a small or noisy sample.
+    """
+    magnitude_readings = {"kills_before_death": [], "revives": [], "damage": []}
+    rate_readings = {"close_range_win": [], "knockdown_conversion": []}
+    matches_analyzed = 0
+    total_kills = 0
+
+    matches = []
+    for events in _load_telemetry_files(match_ids, telemetry_dir):
+        match = _extract_match_readings(account_id, events)
+        if match is not None:
+            matches.append(match)
+
+    matches.sort(key=lambda m: m["match_start"])
+
+    for match in matches:
+        matches_analyzed += 1
+        total_kills += match["kills_before_death"]
+        magnitude_readings["kills_before_death"].append(match["kills_before_death"])
+        magnitude_readings["revives"].append(match["revives"])
+        magnitude_readings["damage"].append(match["damage"])
+        rate_readings["close_range_win"].extend(match["close_range_fights"])
+        rate_readings["knockdown_conversion"].extend(match["knockdown_conversions"])
+
+    matches_with_close_range = sum(1 for m in matches if m["close_range_fights"])
+    matches_with_knockdowns = sum(1 for m in matches if m["knockdown_conversions"])
+
+    candidates = []
+
+    if matches_analyzed >= MIN_MATCHES_FOR_CANDIDATE:
+        values = magnitude_readings["kills_before_death"]
+        if _is_stable(values, 0):
+            candidates.append({
+                "key": "kills_before_death",
+                "score": _score_magnitude(values),
+                "sentence": (
+                    f"Averages {statistics.mean(values):.1f} kills before first death "
+                    f"over your last {matches_analyzed} matches - when they get rolling, "
+                    "they don't stop early"
+                ),
+            })
+
+        values = magnitude_readings["revives"]
+        if _is_stable(values, 0):
+            candidates.append({
+                "key": "revives",
+                "score": _score_magnitude(values),
+                "sentence": (
+                    f"Averages {statistics.mean(values):.1f} revives per match over your "
+                    f"last {matches_analyzed} matches - the squad's safety net"
+                ),
+            })
+
+        values = magnitude_readings["damage"]
+        if _is_stable(values, 0):
+            candidates.append({
+                "key": "damage",
+                "score": _score_magnitude(values),
+                "sentence": (
+                    f"Averages {statistics.mean(values):.0f} damage per match over your "
+                    f"last {matches_analyzed} matches"
+                ),
+            })
+
+    if matches_with_close_range >= MIN_MATCHES_FOR_CANDIDATE:
+        values = rate_readings["close_range_win"]
+        if _is_stable(values, 0.5):
+            wins = sum(values)
+            candidates.append({
+                "key": "close_range_win_rate",
+                "score": _score_rate(values),
+                "sentence": (
+                    f"Wins {statistics.mean(values):.0%} of close-range fights "
+                    f"(inside {CLOSE_RANGE_MAX_METERS}m) - {wins}/{len(values)} across "
+                    f"your last {matches_with_close_range} matches"
+                ),
+            })
+
+    if matches_with_knockdowns >= MIN_MATCHES_FOR_CANDIDATE:
+        values = rate_readings["knockdown_conversion"]
+        if _is_stable(values, 0.5):
+            converted = sum(values)
+            candidates.append({
+                "key": "knockdown_conversion_rate",
+                "score": _score_rate(values),
+                "sentence": (
+                    f"Converts {statistics.mean(values):.0%} of knockdowns into kills - "
+                    f"{converted}/{len(values)} over your last {matches_with_knockdowns} matches"
+                ),
+            })
+
+    if candidates:
+        best = max(candidates, key=lambda c: c["score"])
+        return {
+            "headline": best["sentence"],
+            "stat_key": best["key"],
+            "score": best["score"],
+            "matches_analyzed": matches_analyzed,
+        }
+
+    return {
+        "headline": f"{total_kills} kills over your last {matches_analyzed} matches"
+        if matches_analyzed else "Not enough data yet",
+        "stat_key": "fallback_kill_count",
+        "score": None,
+        "matches_analyzed": matches_analyzed,
+    }

--- a/utils/headline_number.py
+++ b/utils/headline_number.py
@@ -252,8 +252,7 @@ def compute_headline_number(account_id, match_ids=None, telemetry_dir=TELEMETRY_
                 "score": _score_magnitude(values),
                 "sentence": (
                     f"Averages {statistics.mean(values):.1f} kills before first death "
-                    f"over your last {matches_analyzed} matches - when they get rolling, "
-                    "they don't stop early"
+                    f"over your last {matches_analyzed} matches"
                 ),
             })
 
@@ -264,7 +263,7 @@ def compute_headline_number(account_id, match_ids=None, telemetry_dir=TELEMETRY_
                 "score": _score_magnitude(values),
                 "sentence": (
                     f"Averages {statistics.mean(values):.1f} revives per match over your "
-                    f"last {matches_analyzed} matches - the squad's safety net"
+                    f"last {matches_analyzed} matches"
                 ),
             })
 

--- a/utils/last_match_brief.py
+++ b/utils/last_match_brief.py
@@ -13,6 +13,16 @@ MELEE_CAUSERS = {"PlayerFemale_A", "PlayerMale_A"}
 VEHICLE_HINTS = ("Uaz", "Dacia", "Mirado", "Coupe", "PickupTruck", "Buggy", "Motorbike", "Rony", "Van", "Scooter")
 _TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
+# How close in time two teammates' deaths need to be to read as "went down
+# in the same fight" rather than "dead earlier, unrelated". Checked against
+# real teammate-death-gap timing across 250 cached squad matches (10,744
+# gaps): the distribution has no clean bimodal split, but its p60 (~29s)
+# lines up closely with QUICK_KILL_WINDOW_SECONDS in tempo_signal.py (30s,
+# separately calibrated at ~p60 of the contact-to-kill gap) - reusing the
+# same window keeps "quick/connected" framed consistently project-wide
+# rather than picking a second, unrelated constant for a similar question.
+SAME_ENGAGEMENT_WINDOW_SECONDS = 30
+
 
 def _load_telemetry_files(telemetry_dir=TELEMETRY_DIR):
     for path in glob.glob(os.path.join(telemetry_dir, "*-telemetry.json")):
@@ -86,6 +96,72 @@ def _parse_timestamp(value):
     return datetime.strptime(value, _TIMESTAMP_FORMAT) if value else None
 
 
+def _compute_squad_status_at_death(account_id, events, player_death_ts):
+    """Which squadmates were still alive when this player died, and which
+    were already down before it - and if already down, whether that was
+    part of the same fight or unrelated.
+
+    Returns None when there's nothing meaningful to report: the player
+    survived to match end (no death to anchor the comparison), or no other
+    real-player teammates share their teamId (solo, or squad never loaded
+    in for this cached match).
+    """
+    if player_death_ts is None:
+        return None
+
+    team_id = next(
+        (
+            (e.get("character") or {}).get("teamId")
+            for e in events
+            if e.get("_T") == "LogPlayerCreate" and (e.get("character") or {}).get("accountId") == account_id
+        ),
+        None,
+    )
+    if team_id is None:
+        return None
+
+    teammates = {}
+    for event in events:
+        if event.get("_T") != "LogPlayerCreate":
+            continue
+        character = event.get("character") or {}
+        if character.get("type") != "user" or character.get("teamId") != team_id:
+            continue
+        teammate_id = character.get("accountId")
+        if teammate_id != account_id:
+            teammates[teammate_id] = character.get("name", "Unknown")
+
+    if not teammates:
+        return None
+
+    death_ts_by_teammate = {}
+    for event in events:
+        if event.get("_T") != "LogPlayerKillV2" or event.get("isSuicide"):
+            continue
+        killer = event.get("killer") or {}
+        victim = event.get("victim") or {}
+        victim_id = victim.get("accountId")
+        if killer.get("type") != "user" or victim.get("type") != "user" or victim_id not in teammates:
+            continue
+        ts = _parse_timestamp(event.get("_D"))
+        if victim_id not in death_ts_by_teammate or ts < death_ts_by_teammate[victim_id]:
+            death_ts_by_teammate[victim_id] = ts
+
+    squad_status = []
+    for teammate_id, name in teammates.items():
+        teammate_death_ts = death_ts_by_teammate.get(teammate_id)
+
+        if teammate_death_ts is None or teammate_death_ts > player_death_ts:
+            squad_status.append({"name": name, "status": "alive"})
+            continue
+
+        seconds_before = round((player_death_ts - teammate_death_ts).total_seconds(), 1)
+        status = "same_engagement" if seconds_before <= SAME_ENGAGEMENT_WINDOW_SECONDS else "eliminated_earlier"
+        squad_status.append({"name": name, "status": status, "seconds_before": seconds_before})
+
+    return squad_status
+
+
 def compute_last_match_brief(account_id, match_id, events):
     match_start = next((e for e in events if e.get("_T") == "LogMatchStart"), None)
     match_end = next((e for e in events if e.get("_T") == "LogMatchEnd"), None)
@@ -133,6 +209,8 @@ def compute_last_match_brief(account_id, match_id, events):
     end_ts = death_ts or (_parse_timestamp(match_end.get("_D")) if match_end else None)
     time_alive_seconds = int((end_ts - start_ts).total_seconds()) if start_ts and end_ts else None
 
+    squad_status = _compute_squad_status_at_death(account_id, events, death_ts)
+
     return {
         "match_id": match_id,
         "round_rank": round_rank,
@@ -140,4 +218,5 @@ def compute_last_match_brief(account_id, match_id, events):
         "kill_count": kill_count,
         "most_used_weapon": most_used_weapon,
         "death_info": death_info,
+        "squad_status": squad_status,
     }

--- a/utils/last_match_brief.py
+++ b/utils/last_match_brief.py
@@ -1,7 +1,6 @@
 # ==============================
 # utils/last_match_brief.py
 # ==============================
-import glob
 import json
 import os
 from datetime import datetime
@@ -24,24 +23,28 @@ _TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 SAME_ENGAGEMENT_WINDOW_SECONDS = 30
 
 
-def _load_telemetry_files(telemetry_dir=TELEMETRY_DIR):
-    for path in glob.glob(os.path.join(telemetry_dir, "*-telemetry.json")):
-        match_id = os.path.basename(path).replace("-telemetry.json", "")
-        with open(path, "r") as f:
-            yield match_id, json.load(f)
-
-
-def find_latest_match_for_player(account_id, telemetry_dir=TELEMETRY_DIR):
+def find_latest_match_for_player(account_id, candidate_match_ids, telemetry_dir=TELEMETRY_DIR):
     """Return (match_id, events) for the player's most recently played cached match.
 
-    Same LogMatchStart-timestamp approach as bot_detection.find_latest_match,
-    but scoped to matches the given account actually appears in.
+    candidate_match_ids is the player's authoritative match list, straight
+    from the PUBG player-stats API response (see main.py) - this only opens
+    the specific cached files that are actually this player's own, rather
+    than scanning and checking presence across the whole shared telemetry
+    cache (which holds many other players' matches too). Not every
+    candidate match is guaranteed to be cached yet, so missing files are
+    skipped rather than erroring.
     """
     latest_timestamp = None
     latest_match_id = None
     latest_events = None
 
-    for match_id, events in _load_telemetry_files(telemetry_dir):
+    for match_id in candidate_match_ids:
+        path = os.path.join(telemetry_dir, f"{match_id}-telemetry.json")
+        if not os.path.exists(path):
+            continue
+        with open(path, "r") as f:
+            events = json.load(f)
+
         if not player_present_in_match(account_id, events):
             continue
 

--- a/utils/match_scope.py
+++ b/utils/match_scope.py
@@ -1,12 +1,9 @@
 # ==============================
 # utils/match_scope.py
 # ==============================
-import glob
 import json
 import os
 from datetime import datetime, timedelta, timezone
-
-from utils.last_match_brief import player_present_in_match
 
 TELEMETRY_DIR = "match-telemetry"
 
@@ -20,9 +17,8 @@ TELEMETRY_DIR = "match-telemetry"
 # (real-cache benchmarking showed ~0.78s/match per signal, single-
 # threaded) - the intended production default is 250, per the widening
 # spec: 30-day window, +30 days at a time up to 90 days, until 250
-# matches are found or the window maxes out. Revisit once the redundant
-# per-signal file-parsing and match_scope's full-cache scan cost are
-# addressed.
+# matches are found or the window maxes out. Revisit once per-match
+# parse cost at the intended 250-match scale is benchmarked.
 MAX_MATCHES = int(os.getenv("ARCHETYPE_MAX_MATCHES", 50))
 MIN_MATCHES_TARGET = int(os.getenv("ARCHETYPE_MIN_MATCHES_TARGET", 50))
 INITIAL_WINDOW_DAYS = int(os.getenv("ARCHETYPE_INITIAL_WINDOW_DAYS", 30))
@@ -34,26 +30,31 @@ def _parse_timestamp(value):
     return datetime.fromisoformat(value.replace("Z", "+00:00"))
 
 
-def _load_match_dates(account_id, telemetry_dir):
-    """Yield (match_id, match_start) for every cached match the player appears in.
+def _load_match_dates(candidate_match_ids, telemetry_dir):
+    """Yield (match_id, match_start) for this player's own matches that are cached.
 
-    Telemetry caching is shared across players (see README), so the cache
-    holds many matches unrelated to this account - only matches the player
-    actually appears in (via LogPlayerCreate) are candidates.
+    candidate_match_ids is the player's authoritative match list, straight
+    from the PUBG player-stats API response (see main.py) - not every
+    cached telemetry file. The shared telemetry cache holds many matches
+    belonging to other players entirely (see README), so this only ever
+    opens the specific files that are actually this player's own, rather
+    than scanning and checking presence across the whole cache. Not every
+    candidate match is guaranteed to be cached yet (telemetry fetches are
+    rate-limited per run), so missing files are skipped rather than erroring.
     """
-    for path in glob.glob(os.path.join(telemetry_dir, "*-telemetry.json")):
-        match_id = os.path.basename(path).replace("-telemetry.json", "")
+    for match_id in candidate_match_ids:
+        path = os.path.join(telemetry_dir, f"{match_id}-telemetry.json")
+        if not os.path.exists(path):
+            continue
         with open(path, "r") as f:
             events = json.load(f)
-        if not player_present_in_match(account_id, events):
-            continue
         start_event = next((e for e in events if e.get("_T") == "LogMatchStart"), None)
         if not start_event or not start_event.get("_D"):
             continue
         yield match_id, _parse_timestamp(start_event["_D"])
 
 
-def select_scoped_match_ids(account_id, telemetry_dir=TELEMETRY_DIR, now=None):
+def select_scoped_match_ids(candidate_match_ids, telemetry_dir=TELEMETRY_DIR, now=None):
     """Pick which of a player's own cached matches feed the Archetype Tag.
 
     Starts with a recency window of INITIAL_WINDOW_DAYS, widening by
@@ -63,7 +64,7 @@ def select_scoped_match_ids(account_id, telemetry_dir=TELEMETRY_DIR, now=None):
     MAX_MATCHES (most recent first).
     """
     now = now or datetime.now(timezone.utc)
-    dated_matches = sorted(_load_match_dates(account_id, telemetry_dir), key=lambda m: m[1], reverse=True)
+    dated_matches = sorted(_load_match_dates(candidate_match_ids, telemetry_dir), key=lambda m: m[1], reverse=True)
 
     window_days = INITIAL_WINDOW_DAYS
     in_window = []

--- a/utils/squad_read.py
+++ b/utils/squad_read.py
@@ -1,0 +1,182 @@
+# ==============================
+# utils/squad_read.py
+# ==============================
+"""
+Squad Read: a synergy/gap sentence combining two profiled teammates'
+Archetype Tags, bolstered with a data-backed "who opens first" line when
+the pattern is consistent enough to say so with confidence. No named role
+taxonomy - the synergy line is composed directly from the range-bucket and
+temperament deltas between the two players, so it scales to any pairing
+without a hand-authored combo table. See docs/design/storyboard-profile.md's
+"Squad Read" section for the full spec this implements.
+"""
+import json
+import os
+from datetime import datetime
+
+from utils.tempo_signal import compute_time_to_first_contact_from_events
+
+TELEMETRY_DIR = "match-telemetry"
+
+RANGE_ORDER = {"Close-Range": 0, "Mid-Range": 1, "Long-Range": 2}
+TEMPERAMENT_ORDER = {"Aggressive": 0, "Balanced": 1, "Passive": 2}
+
+# "Last N shared matches, need at least K" for the bolstered line - matches
+# the design doc's explicit worked example ("6 of your last 8"). Reuses the
+# project's established MIN_*_FOR_SIGNAL=8 confidence-gating convention
+# rather than a looser all-time percentage.
+BOLSTER_WINDOW = 8
+BOLSTER_THRESHOLD = 5
+
+
+def compute_synergy_line(self_range, self_temperament, teammate_name, teammate_range, teammate_temperament):
+    """The general synergy/gap sentence, composed from the range and
+    temperament deltas between the two players rather than a lookup table
+    of named role combinations.
+
+    Returns None if either player doesn't have enough data for a range
+    bucket or temperament yet (matches the confidence-gating already
+    applied upstream by range_signal.py/tempo_signal.py).
+    """
+    if not all([self_range, self_temperament, teammate_range, teammate_temperament]):
+        return None
+
+    prefix = f"You ({self_range}/{self_temperament}) + {teammate_name} ({teammate_range}/{teammate_temperament})"
+
+    range_delta = RANGE_ORDER[self_range] - RANGE_ORDER[teammate_range]
+    temperament_delta = TEMPERAMENT_ORDER[self_temperament] - TEMPERAMENT_ORDER[teammate_temperament]
+
+    if range_delta == 0 and temperament_delta == 0:
+        if self_temperament == "Aggressive":
+            detail = (
+                "matching aggressive playstyles - you'll both want to be first into the fight. "
+                "Talk before you drop so you're not both pushing the same angle."
+            )
+        elif self_temperament == "Passive":
+            detail = (
+                "matching passive playstyles - neither of you likes to open engagements. "
+                "Expect slower starts, but you'll have each other's range covered when it happens."
+            )
+        else:
+            detail = "closely matched playstyles - predictable to coordinate with, just watch for blind spots you might share."
+        return f"{prefix} = {detail}"
+
+    if range_delta != 0 and temperament_delta == 0:
+        if range_delta < 0:
+            detail = f"same tempo, different distances - you get into the fight up close while {teammate_name} covers from range."
+        else:
+            detail = f"same tempo, different distances - {teammate_name} gets into the fight up close while you cover from range."
+        return f"{prefix} = {detail}"
+
+    if range_delta == 0 and temperament_delta != 0:
+        if temperament_delta < 0:
+            detail = "similar range, but you tend to commit sooner - you'll typically be first into engagements."
+        else:
+            detail = f"similar range, but {teammate_name} tends to commit sooner - expect them to be first into engagements."
+        return f"{prefix} = {detail}"
+
+    closer_is_self = range_delta < 0
+    faster_is_self = temperament_delta < 0
+    if closer_is_self == faster_is_self:
+        if closer_is_self:
+            detail = f"classic push-and-cover: you push in, {teammate_name} holds the angle."
+        else:
+            detail = f"classic push-and-cover: {teammate_name} pushes in, you hold your angle."
+        return f"{prefix} = {detail}"
+
+    detail = (
+        "an unusual mix - your instincts pull in different directions (one of you commits fast but "
+        "from range, the other holds close and waits). Worth talking through positioning before you push."
+    )
+    return f"{prefix} = {detail}"
+
+
+def _load_dated_events(match_ids, telemetry_dir):
+    for match_id in match_ids:
+        path = os.path.join(telemetry_dir, f"{match_id}-telemetry.json")
+        if not os.path.exists(path):
+            continue
+        with open(path, "r") as f:
+            events = json.load(f)
+        start_event = next((e for e in events if e.get("_T") == "LogMatchStart"), None)
+        if not start_event or not start_event.get("_D"):
+            continue
+        yield events, datetime.fromisoformat(start_event["_D"].replace("Z", "+00:00"))
+
+
+def compute_engagement_lead(self_id, teammate_id, teammate_name, shared_match_ids, telemetry_dir=TELEMETRY_DIR):
+    """Bolstered "who opens first" line, or None if the pattern isn't
+    consistent (or common) enough across the most recent shared matches to
+    say so with confidence.
+
+    "Opens first" compares each player's own time-to-first-contact
+    (tempo_signal.py) within the same match - whichever of the two made
+    contact with a real player earlier is the one who opened that match's
+    engagement for the squad. Only matches where both players have a valid
+    contact reading count (a match one of them never engaged in isn't a
+    fair comparison). Reuses tempo_signal's own presence/contact logic
+    rather than re-deriving it.
+    """
+    dated_openers = []
+    for events, match_start in _load_dated_events(shared_match_ids, telemetry_dir):
+        self_reading = compute_time_to_first_contact_from_events(self_id, events)
+        teammate_reading = compute_time_to_first_contact_from_events(teammate_id, events)
+        if not self_reading or not teammate_reading:
+            continue
+
+        self_seconds = self_reading["contact_seconds"]
+        teammate_seconds = teammate_reading["contact_seconds"]
+        if self_seconds is None or teammate_seconds is None or self_seconds == teammate_seconds:
+            continue
+
+        opener = "you" if self_seconds < teammate_seconds else teammate_name
+        dated_openers.append((match_start, opener))
+
+    dated_openers.sort(key=lambda r: r[0], reverse=True)
+    recent_window = dated_openers[:BOLSTER_WINDOW]
+
+    if len(recent_window) < BOLSTER_WINDOW:
+        return None
+
+    counts = {}
+    for _, opener in recent_window:
+        counts[opener] = counts.get(opener, 0) + 1
+
+    leader, count = max(counts.items(), key=lambda kv: kv[1])
+    if count < BOLSTER_THRESHOLD:
+        return None
+
+    if leader == "you":
+        return f"High confidence: you've opened the first engagement in {count} of your last {len(recent_window)} shared matches."
+    return (
+        f"High confidence: {leader} has opened the first engagement in {count} of your last "
+        f"{len(recent_window)} shared matches - expect {leader} to push first."
+    )
+
+
+def compute_squad_read(
+    self_id, self_archetype, self_match_ids,
+    teammate_id, teammate_name, teammate_archetype, teammate_match_ids,
+    telemetry_dir=TELEMETRY_DIR,
+):
+    """Combine the general synergy line with the bolstered "opens first"
+    line (when confident enough) into the full Squad Read.
+    """
+    synergy_line = compute_synergy_line(
+        self_archetype["range"]["range_bucket"],
+        self_archetype["temperament"],
+        teammate_name,
+        teammate_archetype["range"]["range_bucket"],
+        teammate_archetype["temperament"],
+    )
+
+    shared_match_ids = set(self_match_ids) & set(teammate_match_ids)
+    bolstered_line = compute_engagement_lead(
+        self_id, teammate_id, teammate_name, shared_match_ids, telemetry_dir=telemetry_dir
+    )
+
+    return {
+        "synergy_line": synergy_line,
+        "bolstered_line": bolstered_line,
+        "shared_matches_analyzed": len(shared_match_ids),
+    }

--- a/utils/squad_read.py
+++ b/utils/squad_read.py
@@ -104,10 +104,10 @@ def _load_dated_events(match_ids, telemetry_dir):
         yield events, datetime.fromisoformat(start_event["_D"].replace("Z", "+00:00"))
 
 
-def compute_engagement_lead(self_id, teammate_id, teammate_name, shared_match_ids, telemetry_dir=TELEMETRY_DIR):
-    """Bolstered "who opens first" line, or None if the pattern isn't
-    consistent (or common) enough across the most recent shared matches to
-    say so with confidence.
+def compute_engagement_lead_stats(self_id, teammate_id, shared_match_ids, telemetry_dir=TELEMETRY_DIR):
+    """Who opens first more often, as structured data - or None if the
+    pattern isn't consistent (or common) enough across the most recent
+    shared matches to say so with confidence.
 
     "Opens first" compares each player's own time-to-first-contact
     (tempo_signal.py) within the same match - whichever of the two made
@@ -116,6 +116,11 @@ def compute_engagement_lead(self_id, teammate_id, teammate_name, shared_match_id
     contact reading count (a match one of them never engaged in isn't a
     fair comparison). Reuses tempo_signal's own presence/contact logic
     rather than re-deriving it.
+
+    Returns {"leader": "self"|"teammate", "count": N, "window": N} - kept
+    structured (not pre-formatted into a sentence) so callers comparing
+    multiple teammates (Squad Roster) can pick the strongest result before
+    formatting anything.
     """
     dated_openers = []
     for events, match_start in _load_dated_events(shared_match_ids, telemetry_dir):
@@ -129,7 +134,7 @@ def compute_engagement_lead(self_id, teammate_id, teammate_name, shared_match_id
         if self_seconds is None or teammate_seconds is None or self_seconds == teammate_seconds:
             continue
 
-        opener = "you" if self_seconds < teammate_seconds else teammate_name
+        opener = "self" if self_seconds < teammate_seconds else "teammate"
         dated_openers.append((match_start, opener))
 
     dated_openers.sort(key=lambda r: r[0], reverse=True)
@@ -146,12 +151,27 @@ def compute_engagement_lead(self_id, teammate_id, teammate_name, shared_match_id
     if count < BOLSTER_THRESHOLD:
         return None
 
-    if leader == "you":
-        return f"High confidence: you've opened the first engagement in {count} of your last {len(recent_window)} shared matches."
+    return {"leader": leader, "count": count, "window": len(recent_window)}
+
+
+def format_engagement_lead(stats, teammate_name):
+    """Render compute_engagement_lead_stats' structured result as the
+    "High confidence" display sentence."""
+    if stats is None:
+        return None
+    if stats["leader"] == "self":
+        return f"High confidence: you've opened the first engagement in {stats['count']} of your last {stats['window']} shared matches."
     return (
-        f"High confidence: {leader} has opened the first engagement in {count} of your last "
-        f"{len(recent_window)} shared matches - expect {leader} to push first."
+        f"High confidence: {teammate_name} has opened the first engagement in {stats['count']} of your last "
+        f"{stats['window']} shared matches - expect {teammate_name} to push first."
     )
+
+
+def compute_engagement_lead(self_id, teammate_id, teammate_name, shared_match_ids, telemetry_dir=TELEMETRY_DIR):
+    """Bolstered "who opens first" display line for the two-player case
+    (Squad Read) - combines compute_engagement_lead_stats + format_engagement_lead."""
+    stats = compute_engagement_lead_stats(self_id, teammate_id, shared_match_ids, telemetry_dir=telemetry_dir)
+    return format_engagement_lead(stats, teammate_name)
 
 
 def compute_squad_read(

--- a/utils/squad_roster.py
+++ b/utils/squad_roster.py
@@ -1,0 +1,155 @@
+# ==============================
+# utils/squad_roster.py
+# ==============================
+"""
+Squad Roster: the at-a-glance summary for 2+ profiled teammates. Describes
+the squad's range/temperament coverage (which ranges are represented,
+which are missing, how aggression distributes) rather than combining
+pairwise Squad Read lines - see docs/design/storyboard-profile.md's
+"Squad Roster summary view" section.
+
+Per-member role callouts ("entry fragger", "support anchor") are derived
+directly from that member's own (range, temperament) pair, not a
+hand-authored combo table - each member is classified independently, then
+the squad-level text is composed from those classifications.
+"""
+from utils.squad_read import compute_engagement_lead_stats, format_engagement_lead
+
+TELEMETRY_DIR = "match-telemetry"
+
+RANGE_ORDER = ["Close-Range", "Mid-Range", "Long-Range"]
+
+
+def _member_role(range_bucket, temperament):
+    if temperament == "Aggressive" and range_bucket == "Close-Range":
+        return "entry fragger"
+    if temperament == "Passive":
+        return "support anchor"
+    if temperament == "Aggressive":
+        return "aggressive skirmisher"
+    return None
+
+
+def _join_names(names):
+    if len(names) == 1:
+        return names[0]
+    if len(names) == 2:
+        return f"{names[0]} and {names[1]}"
+    return f"{', '.join(names[:-1])}, and {names[-1]}"
+
+
+def _display_name(member, is_self):
+    return "you" if is_self else member["name"]
+
+
+def compute_squad_coverage_summary(members):
+    """The squad-level range/temperament coverage paragraph.
+
+    members[0] is always "you" (the profile-owner perspective). Members
+    without a resolved range bucket or temperament yet (not enough data)
+    are excluded from the coverage analysis entirely, same confidence-
+    gating philosophy as the rest of the Archetype Tag signals.
+    """
+    profiled = [
+        (i, m) for i, m in enumerate(members)
+        if m["archetype"]["range"]["range_bucket"] and m["archetype"]["temperament"]
+    ]
+    if len(profiled) < 2:
+        return None
+
+    temperaments = [m["archetype"]["temperament"] for _, m in profiled]
+    distinct_temperaments = set(temperaments)
+
+    if "Aggressive" in distinct_temperaments and "Passive" in distinct_temperaments:
+        opener = "Balanced squad"
+    elif len(distinct_temperaments) == 1:
+        opener = f"All-{next(iter(distinct_temperaments))} squad"
+    else:
+        opener = "Squad"
+
+    role_clauses = []
+    leftover = []
+    for i, m in profiled:
+        range_bucket = m["archetype"]["range"]["range_bucket"]
+        temperament = m["archetype"]["temperament"]
+        role = _member_role(range_bucket, temperament)
+        name = _display_name(m, is_self=(i == 0))
+        if role:
+            role_clauses.append(f"{name} ({role})")
+        else:
+            leftover.append((name, range_bucket))
+
+    if leftover:
+        leftover_names = _join_names([name for name, _ in leftover])
+        leftover_bucket_indices = sorted({RANGE_ORDER.index(bucket) for _, bucket in leftover})
+        if len(leftover_bucket_indices) == 1:
+            span = RANGE_ORDER[leftover_bucket_indices[0]].replace("-Range", "").lower() + "-range"
+        else:
+            low = RANGE_ORDER[leftover_bucket_indices[0]].replace("-Range", "")
+            high = RANGE_ORDER[leftover_bucket_indices[-1]].replace("-Range", "")
+            span = f"{low.lower()}-to-{high.lower()}"
+        role_clauses.append(f"{leftover_names} cover {span}")
+
+    range_buckets_present = {m["archetype"]["range"]["range_bucket"] for _, m in profiled}
+    missing_buckets = [b for b in RANGE_ORDER if b not in range_buckets_present]
+
+    if missing_buckets:
+        gap_names = ", ".join(b.lower() for b in missing_buckets)
+        concluding = f"No one covers {gap_names} - you may be exposed there."
+    else:
+        concluding = "No overlapping blind spots."
+
+    return f"{opener}: {', '.join(role_clauses)}. {concluding}"
+
+
+def compute_best_engagement_lead(members, telemetry_dir=TELEMETRY_DIR):
+    """The single strongest "opens first" bolstered line, comparing "you"
+    (members[0]) against each teammate and surfacing whichever comparison
+    clears the confidence bar with the highest count - matches the design
+    doc's mockup, which highlights exactly one standout teammate rather
+    than a line per pairing.
+    """
+    if len(members) < 2:
+        return None
+
+    self_member = members[0]
+    best_teammate_name = None
+    best_stats = None
+
+    for teammate in members[1:]:
+        stats = compute_engagement_lead_stats(
+            self_member["account_id"],
+            teammate["account_id"],
+            set(self_member["match_ids"]) & set(teammate["match_ids"]),
+            telemetry_dir=telemetry_dir,
+        )
+        if stats is None:
+            continue
+        if best_stats is None or stats["count"] > best_stats["count"]:
+            best_stats = stats
+            best_teammate_name = teammate["name"]
+
+    return format_engagement_lead(best_stats, best_teammate_name)
+
+
+def compute_squad_roster(members, telemetry_dir=TELEMETRY_DIR):
+    """Full Squad Roster: per-member summary rows plus the squad-level
+    coverage/distribution read and the single strongest bolstered line.
+
+    members: list of {"name", "account_id", "archetype", "match_ids"},
+    members[0] is "you".
+    """
+    roster_rows = [
+        {
+            "name": "You" if i == 0 else m["name"],
+            "tempo_tag": m["archetype"]["tempo"]["tempo_tag"],
+            "short_tag": m["archetype"]["short_tag"],
+        }
+        for i, m in enumerate(members)
+    ]
+
+    return {
+        "roster_rows": roster_rows,
+        "coverage_summary": compute_squad_coverage_summary(members),
+        "bolstered_line": compute_best_engagement_lead(members, telemetry_dir=telemetry_dir),
+    }


### PR DESCRIPTION
## Summary

Completes Mode 1 of the storyboard profile: Archetype Tag, Weapon Signature, Headline Number, Last Match Snapshot, Squad Read, and Squad Roster, plus the Data Budget/Fetch Policy scoping that backs them all.

- **Archetype Tag** (tempo + range + weapon) - real-data-calibrated thresholds, not guessed
- **Headline Number** - one differentiating, confidence-gated stat from a 5-candidate pool, picked via proportion/t-tests rather than a single blended formula
- **Last Match Snapshot** - adds squad-status-at-death (who was still alive vs. already eliminated when you died)
- **Squad Read** - synergy/gap line composed from range + temperament deltas between two players, bolstered with a data-backed "who opens first" line
- **Squad Roster** - coverage/distribution summary for 2+ teammates, plus a full card per teammate
- **`squad.py`** - new multi-player entry point (concurrent stats fetch, one deduplicated telemetry fetch across the whole squad); `main.py`'s single-player flow is untouched
- Fixed a real perf bug: match-selection was scanning and parsing the entire shared telemetry cache instead of using the player's own already-known match list from the player-stats API - confirmed byte-identical results, ~130x faster on real data
- Fixed a real bug: "Time Survived (min)" was showing raw seconds due to a case-sensitive key check
- Did a full sentence-to-math correctness pass across every text-generating module before opening this PR - traced each displayed sentence by hand against its underlying computed value; found and fixed two real mismatches (a mislabeled "early contact" count, and flavor text that didn't scale with the actual number)

## Test plan

- [x] 123 unit tests passing (`python -m unittest discover tests`)
- [x] `doctor.py` all green, including live PUBG API heartbeat
- [x] Verified end-to-end against real cached players (not just synthetic fixtures) for every new capability
- [x] Verified the match-selection perf fix produces byte-identical output to the old implementation before replacing it
- [x] Verified `main.py`'s single-player flow is unchanged via live before/after re-run
- [x] Verified `squad.py` end-to-end against two real players with 53 shared matches
- [ ] Live test on Windows via `git pull` + `setup.ps1`