### PR TITLE
Add safety margin to API rate limiter pacing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,10 @@
 PUBG_API_KEY=your_api_key_here
 
 # Optional: default rate limit (requests/minute) for /players and /seasons
-# calls, used until the API's response headers take over. Defaults to 10.
+# calls, used until the API's response headers take over. Defaults to 10,
+# PUBG's documented default key limit - actual pacing stays at 85% of
+# whichever limit is active (this default, or the live X-RateLimit-Limit
+# once seen) as a safety margin, see api/rate_limiter.py.
 PUBG_RATE_LIMIT_PER_MINUTE=10
 
 # Optional: how many telemetry files fetch concurrently. Defaults to 3.

--- a/api/rate_limiter.py
+++ b/api/rate_limiter.py
@@ -17,13 +17,21 @@ if not logger.handlers:
 
 DEFAULT_LIMIT_PER_MINUTE = int(os.getenv("PUBG_RATE_LIMIT_PER_MINUTE", 10))
 
+# PUBG's documented default API key limit is 10 requests/minute
+# (https://documentation.pubg.com/en/rate-limits.html). Pace requests to
+# only this fraction of whatever limit is in effect - the configured
+# default or, once seen, the live X-RateLimit-Limit value - so normal
+# jitter/timing never trips the API's own 429 threshold.
+SAFETY_MARGIN = 0.85
+
 
 class RateLimitedQueue:
     """Serializes requests to rate-limited PUBG API endpoints.
 
     Falls back to a configurable default rate (requests/minute) until the
     API's X-RateLimit-* response headers are seen, then throttles against
-    the reported Limit/Remaining/Reset instead.
+    the reported Limit/Remaining/Reset instead. Actual pacing stays at
+    SAFETY_MARGIN of whichever limit is active, never the full rate.
     """
 
     def __init__(self, default_limit_per_minute=DEFAULT_LIMIT_PER_MINUTE):
@@ -52,11 +60,12 @@ class RateLimitedQueue:
             return
 
         if self._last_request_at is not None:
-            min_interval = 60.0 / self._limit
+            paced_limit = self._limit * SAFETY_MARGIN
+            min_interval = 60.0 / paced_limit
             elapsed = time.time() - self._last_request_at
             if elapsed < min_interval:
                 wait_time = min_interval - elapsed
-                logger.info(f"Throttling to {self._limit}/min, waiting {wait_time:.1f}s")
+                logger.info(f"Throttling to {paced_limit:.1f}/min ({SAFETY_MARGIN:.0%} of {self._limit}/min), waiting {wait_time:.1f}s")
                 await asyncio.sleep(wait_time)
 
     def _update_from_headers(self, headers):

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -7,7 +7,7 @@ import time
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from api.rate_limiter import RateLimitedQueue
+from api.rate_limiter import RateLimitedQueue, SAFETY_MARGIN
 
 
 def make_mock_session(headers, json_data):
@@ -57,7 +57,7 @@ class TestRateLimitedQueue(unittest.IsolatedAsyncioTestCase):
         self.assertLessEqual(waited, 5)
 
     async def test_throttles_to_default_interval_without_headers(self):
-        queue = RateLimitedQueue(default_limit_per_minute=60)  # 1 req/sec
+        queue = RateLimitedQueue(default_limit_per_minute=60)  # paced to 60*SAFETY_MARGIN/min
         queue._last_request_at = time.time()
 
         with patch("api.rate_limiter.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
@@ -65,8 +65,23 @@ class TestRateLimitedQueue(unittest.IsolatedAsyncioTestCase):
 
         mock_sleep.assert_awaited_once()
         waited = mock_sleep.call_args.args[0]
+        expected_interval = 60.0 / (60 * SAFETY_MARGIN)
         self.assertGreater(waited, 0)
-        self.assertLessEqual(waited, 1)
+        self.assertLessEqual(waited, expected_interval)
+
+    async def test_pacing_applies_safety_margin_below_reported_limit(self):
+        # A bare 10/min limit should be paced to 10*SAFETY_MARGIN/min, not
+        # the full 10 - guards against normal timing jitter tripping the
+        # API's own 429 threshold right at the documented ceiling.
+        queue = RateLimitedQueue(default_limit_per_minute=10)
+        queue._last_request_at = time.time()
+
+        with patch("api.rate_limiter.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            await queue._wait_for_slot()
+
+        waited = mock_sleep.call_args.args[0]
+        full_rate_interval = 60.0 / 10
+        self.assertGreater(waited, full_rate_interval)
 
     async def test_no_wait_when_remaining_available(self):
         queue = RateLimitedQueue(default_limit_per_minute=10)


### PR DESCRIPTION
## Summary
- PUBG's documented default key limit is 10 requests/minute; pacing now stays at 85% of whichever limit is active (configured default or live X-RateLimit-Limit) instead of the full rate.

## Test plan
- [x] `python -m unittest discover tests` passes
- [x] `python doctor.py` passes

Closes #37