### PR TITLE
Polish squad.py output: possessive fixes, layout, K/D stat

### DIFF
--- a/squad.py
+++ b/squad.py
@@ -19,6 +19,7 @@ from api.player_stats import fetch_player_and_match_ids
 from api.rate_limiter import player_api_queue
 from api.telemetry_fetcher import fetch_telemetry_for_matches
 from utils.archetype_tag import compute_archetype_tag
+from utils.combat_stats import compute_combat_stats
 from utils.headline_number import compute_headline_number
 from utils.match_scope import select_scoped_match_ids
 from utils.squad_roster import compute_squad_roster
@@ -57,18 +58,21 @@ async def _run(playernames):
 
     archetypes = {}
     headlines = {}
-    for m in members:
+    combat_stats = {}
+    for i, m in enumerate(members):
         scoped = set(select_scoped_match_ids(m["match_ids"]))
+        possessive = "your" if i == 0 else "their"
         archetype = compute_archetype_tag(m["account_id"], match_ids=scoped)
         m["archetype"] = archetype
         archetypes[m["name"]] = archetype
-        headlines[m["name"]] = compute_headline_number(m["account_id"], match_ids=scoped)
+        headlines[m["name"]] = compute_headline_number(m["account_id"], match_ids=scoped, possessive=possessive)
+        combat_stats[m["name"]] = compute_combat_stats(m["account_id"], match_ids=scoped)
 
     roster = compute_squad_roster(members)
 
     print("\n\n")
     render_squad_roster(roster)
-    render_full_squad_cards(members, archetypes, headlines)
+    render_full_squad_cards(members, archetypes, headlines, combat_stats)
 
 
 def main():

--- a/tests/test_headline_number.py
+++ b/tests/test_headline_number.py
@@ -198,6 +198,18 @@ class TestComputeHeadlineNumber(unittest.TestCase):
 
         self.assertIn(str(result["matches_analyzed"]), result["headline"])
 
+    def test_possessive_defaults_to_your_but_is_overridable(self):
+        # squad.py renders teammate cards with possessive="their" - "your"
+        # would misattribute the teammate's own stats to the running user.
+        for day in range(1, MIN_MATCHES_FOR_CANDIDATE - 1):
+            self._write_match(day, [kill_event(ME, RIVAL)])
+
+        default_result = compute_headline_number(ME, telemetry_dir=self.tmpdir.name)
+        their_result = compute_headline_number(ME, telemetry_dir=self.tmpdir.name, possessive="their")
+
+        self.assertIn("your last", default_result["headline"])
+        self.assertIn("their last", their_result["headline"])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_squad_roster.py
+++ b/tests/test_squad_roster.py
@@ -57,7 +57,7 @@ class TestComputeSquadCoverageSummary(unittest.TestCase):
         result = compute_squad_coverage_summary(members)
 
         self.assertIn("Balanced squad", result)
-        self.assertIn("you (support anchor)", result)
+        self.assertIn("You (support anchor)", result)
         self.assertIn("DanucD (entry fragger)", result)
         self.assertIn("Vacency cover", result)
         self.assertIn("No overlapping blind spots.", result)
@@ -70,6 +70,19 @@ class TestComputeSquadCoverageSummary(unittest.TestCase):
         result = compute_squad_coverage_summary(members)
 
         self.assertIn("All-Aggressive squad", result)
+
+    def test_mixed_temperament_squad_uses_mixed_opener_not_generic_squad(self):
+        # Aggressive + Balanced (no Passive) doesn't fit "Balanced squad"
+        # (needs Aggressive+Passive) or "All-X squad" (needs one temperament) -
+        # falls to the generic case, which should read "Mixed squad", not the
+        # bare word "Squad" that collided with the "Squad Read:" print prefix.
+        members = [
+            member("You", ME, "Close-Range", "Aggressive"),
+            member("Mate", MATE_A, "Mid-Range", "Balanced"),
+        ]
+        result = compute_squad_coverage_summary(members)
+
+        self.assertIn("Mixed squad", result)
 
     def test_flags_missing_range_coverage(self):
         members = [
@@ -87,7 +100,7 @@ class TestComputeSquadCoverageSummary(unittest.TestCase):
         ]
         result = compute_squad_coverage_summary(members)
 
-        self.assertIn("you and Mate cover close-to-long", result)
+        self.assertIn("You and Mate cover close-to-long", result)
 
 
 class TestComputeBestEngagementLead(unittest.TestCase):

--- a/utils/display_combat_stats.py
+++ b/utils/display_combat_stats.py
@@ -2,6 +2,24 @@
 # utils/display_combat_stats.py
 # ==============================
 
+# Matches the MIN_*_FOR_SIGNAL=8 confidence-gating convention used across
+# tempo/range/weapon/headline signals.
+MIN_MATCHES_FOR_KD = 8
+
+
+def render_kd_summary(stats):
+    """Compact single-line K/D summary for a squad card - the full
+    eliminations/deaths breakdown (render_combat_stats) is main.py's
+    single-player view, not needed on a per-teammate card."""
+    matches_analyzed = stats["matches_analyzed"]
+    if matches_analyzed < MIN_MATCHES_FOR_KD:
+        print(f"K/D    : Not enough data ({matches_analyzed} matches, need {MIN_MATCHES_FOR_KD}+)")
+        return
+    total_elims = stats["total_eliminations"]
+    total_deaths = stats["total_deaths"]
+    kd = total_elims / total_deaths if total_deaths else float(total_elims)
+    print(f"K/D    : {kd:.2f}  ({total_elims}/{total_deaths} across {matches_analyzed} matches)")
+
 
 def render_combat_stats(stats):
     total_elims = stats["total_eliminations"]

--- a/utils/display_squad_roster.py
+++ b/utils/display_squad_roster.py
@@ -2,6 +2,7 @@
 # utils/display_squad_roster.py
 # ==============================
 from utils.display_archetype_tag import render_archetype_tag
+from utils.display_combat_stats import render_kd_summary
 from utils.display_headline_number import render_headline_number
 
 NAME_WIDTH = 14
@@ -10,7 +11,7 @@ TAG_WIDTH = 24
 
 def render_squad_roster(roster):
     print("=============================================")
-    print("🎮 SQUAD ROSTER - At a Glance")
+    print("🎮 SQUAD ROSTER")
     print("=============================================")
 
     for row in roster["roster_rows"]:
@@ -28,13 +29,20 @@ def render_squad_roster(roster):
     print("=============================================")
 
 
-def render_full_squad_cards(members, archetypes, headlines):
-    """Full per-player 5-slot cards after the roster summary - members[0]
-    is "you", already shown in the roster table above so only teammates
-    get a full card here (matches the design doc's mockup)."""
-    for member in members[1:]:
-        name = member["name"]
+def render_full_squad_cards(members, archetypes, headlines, combat_stats):
+    """Full per-player cards after the roster summary. Teammates render
+    first, then "you" last regardless of argument order - the running
+    user's own card is the one they already know, so it reads better as
+    the closer than the opener."""
+    ordered = members[1:] + [members[0]]
+    for i, member in enumerate(ordered):
+        is_self = (i == len(ordered) - 1)
+        key = member["name"]
+        display_name = "You" if is_self else key
         print()
-        print(f"--- {name} ---")
-        render_archetype_tag(archetypes[name])
-        render_headline_number(headlines[name])
+        print("=============================================")
+        print(f"👤 {display_name}")
+        print("=============================================")
+        render_archetype_tag(archetypes[key])
+        render_headline_number(headlines[key])
+        render_kd_summary(combat_stats[key])

--- a/utils/headline_number.py
+++ b/utils/headline_number.py
@@ -208,7 +208,7 @@ def _score_magnitude(ordered_values):
     return mean / standard_error
 
 
-def compute_headline_number(account_id, match_ids=None, telemetry_dir=TELEMETRY_DIR):
+def compute_headline_number(account_id, match_ids=None, telemetry_dir=TELEMETRY_DIR, possessive="your"):
     """Pick the single most differentiating, confidence-gated stat.
 
     Evaluates a fixed pool of candidates, keeps only those with enough
@@ -216,6 +216,10 @@ def compute_headline_number(account_id, match_ids=None, telemetry_dir=TELEMETRY_
     whichever eligible candidate scores highest. Falls back to a plain
     kill count if nothing clears the bar, rather than force a shaky
     "notable" stat onto a small or noisy sample.
+
+    possessive: pronoun used in the rendered sentence ("your" for the
+    CLI's own user in main.py, "their" when squad.py renders a
+    teammate's card).
     """
     magnitude_readings = {"kills_before_death": [], "revives": [], "damage": []}
     rate_readings = {"close_range_win": [], "knockdown_conversion": []}
@@ -252,7 +256,7 @@ def compute_headline_number(account_id, match_ids=None, telemetry_dir=TELEMETRY_
                 "score": _score_magnitude(values),
                 "sentence": (
                     f"Averages {statistics.mean(values):.1f} kills before first death "
-                    f"over your last {matches_analyzed} matches"
+                    f"over {possessive} last {matches_analyzed} matches"
                 ),
             })
 
@@ -262,7 +266,7 @@ def compute_headline_number(account_id, match_ids=None, telemetry_dir=TELEMETRY_
                 "key": "revives",
                 "score": _score_magnitude(values),
                 "sentence": (
-                    f"Averages {statistics.mean(values):.1f} revives per match over your "
+                    f"Averages {statistics.mean(values):.1f} revives per match over {possessive} "
                     f"last {matches_analyzed} matches"
                 ),
             })
@@ -273,7 +277,7 @@ def compute_headline_number(account_id, match_ids=None, telemetry_dir=TELEMETRY_
                 "key": "damage",
                 "score": _score_magnitude(values),
                 "sentence": (
-                    f"Averages {statistics.mean(values):.0f} damage per match over your "
+                    f"Averages {statistics.mean(values):.0f} damage per match over {possessive} "
                     f"last {matches_analyzed} matches"
                 ),
             })
@@ -288,7 +292,7 @@ def compute_headline_number(account_id, match_ids=None, telemetry_dir=TELEMETRY_
                 "sentence": (
                     f"Wins {statistics.mean(values):.0%} of close-range fights "
                     f"(inside {CLOSE_RANGE_MAX_METERS}m) - {wins}/{len(values)} across "
-                    f"your last {matches_with_close_range} matches"
+                    f"{possessive} last {matches_with_close_range} matches"
                 ),
             })
 
@@ -301,7 +305,7 @@ def compute_headline_number(account_id, match_ids=None, telemetry_dir=TELEMETRY_
                 "score": _score_rate(values),
                 "sentence": (
                     f"Converts {statistics.mean(values):.0%} of knockdowns into kills - "
-                    f"{converted}/{len(values)} over your last {matches_with_knockdowns} matches"
+                    f"{converted}/{len(values)} over {possessive} last {matches_with_knockdowns} matches"
                 ),
             })
 
@@ -315,7 +319,7 @@ def compute_headline_number(account_id, match_ids=None, telemetry_dir=TELEMETRY_
         }
 
     return {
-        "headline": f"{total_kills} kills over your last {matches_analyzed} matches"
+        "headline": f"{total_kills} kills over {possessive} last {matches_analyzed} matches"
         if matches_analyzed else "Not enough data yet",
         "stat_key": "fallback_kill_count",
         "score": None,

--- a/utils/squad_read.py
+++ b/utils/squad_read.py
@@ -160,10 +160,13 @@ def format_engagement_lead(stats, teammate_name):
     if stats is None:
         return None
     if stats["leader"] == "self":
-        return f"High confidence: you've opened the first engagement in {stats['count']} of your last {stats['window']} shared matches."
+        return (
+            f"High confidence: You tend to push first - you've opened the first engagement "
+            f"in {stats['count']} of your last {stats['window']} shared matches."
+        )
     return (
-        f"High confidence: {teammate_name} has opened the first engagement in {stats['count']} of your last "
-        f"{stats['window']} shared matches - expect {teammate_name} to push first."
+        f"High confidence: Expect {teammate_name} to push first - {teammate_name} has opened "
+        f"the first engagement in {stats['count']} of your last {stats['window']} shared matches."
     )
 
 

--- a/utils/squad_roster.py
+++ b/utils/squad_roster.py
@@ -42,6 +42,16 @@ def _display_name(member, is_self):
     return "you" if is_self else member["name"]
 
 
+def _sentence_case(text):
+    """Capitalize a composed sentence's leading "you" (the generic
+    self-pronoun) without mangling a real player name that happens to
+    lead a different sentence - names keep whatever case they already
+    have."""
+    if text.startswith("you "):
+        return "You" + text[3:]
+    return text
+
+
 def compute_squad_coverage_summary(members):
     """The squad-level range/temperament coverage paragraph.
 
@@ -65,7 +75,7 @@ def compute_squad_coverage_summary(members):
     elif len(distinct_temperaments) == 1:
         opener = f"All-{next(iter(distinct_temperaments))} squad"
     else:
-        opener = "Squad"
+        opener = "Mixed squad"
 
     role_clauses = []
     leftover = []
@@ -79,6 +89,11 @@ def compute_squad_coverage_summary(members):
         else:
             leftover.append((name, range_bucket))
 
+    sentences = []
+    if role_clauses:
+        text = f"{_join_names(role_clauses)}."
+        sentences.append(_sentence_case(text))
+
     if leftover:
         leftover_names = _join_names([name for name, _ in leftover])
         leftover_bucket_indices = sorted({RANGE_ORDER.index(bucket) for _, bucket in leftover})
@@ -88,7 +103,8 @@ def compute_squad_coverage_summary(members):
             low = RANGE_ORDER[leftover_bucket_indices[0]].replace("-Range", "")
             high = RANGE_ORDER[leftover_bucket_indices[-1]].replace("-Range", "")
             span = f"{low.lower()}-to-{high.lower()}"
-        role_clauses.append(f"{leftover_names} cover {span}")
+        text = f"{leftover_names} cover {span}."
+        sentences.append(_sentence_case(text))
 
     range_buckets_present = {m["archetype"]["range"]["range_bucket"] for _, m in profiled}
     missing_buckets = [b for b in RANGE_ORDER if b not in range_buckets_present]
@@ -99,7 +115,7 @@ def compute_squad_coverage_summary(members):
     else:
         concluding = "No overlapping blind spots."
 
-    return f"{opener}: {', '.join(role_clauses)}. {concluding}"
+    return f"{opener}: {' '.join(sentences)} {concluding}"
 
 
 def compute_best_engagement_lead(members, telemetry_dir=TELEMETRY_DIR):


### PR DESCRIPTION
## Summary
- Fixes possessive/tense mismatches on teammate cards ("your" -> "their")
- Renames the Squad Read fallback opener to remove the redundant "Squad:" collision
- Includes the running user's own card in the full card list, ordered last
- Reorders the "opens first" line to lead with the outcome
- Gives player cards a clearer visual separator
- Drops "- At a Glance" from the roster title
- Adds a K/D stat to each player's card

## Test plan
- [x] `python -m unittest discover tests` passes
- [x] `python doctor.py` passes
- [x] Validated live against real cached players (`squad.py ashleykan hwinn shane_doe`), including a re-run after fixing a casing bug found in the first pass

Closes #36