### PR TITLE
Add solo.py: narrative single-player profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ powershell -ExecutionPolicy Bypass -File setup.ps1
 Then profile a player:
 
 ```powershell
-python main.py PlayerName
+python solo.py PlayerName
 ```
 
 Or a whole squad at once (2+ players, you first):
@@ -50,6 +50,9 @@ Or a whole squad at once (2+ players, you first):
 ```powershell
 python squad.py YourName Teammate1 Teammate2
 ```
+
+Want the full raw stats dump (every stat, full match history, full combat
+breakdown) instead of the narrative profile? Use `python main.py PlayerName`.
 
 Re-run `python doctor.py` any time to re-check your environment without
 redoing setup.

--- a/docs/development.md
+++ b/docs/development.md
@@ -34,7 +34,7 @@ python doctor.py
 5. Run it against a player name:
 
 ```bash
-python main.py PlayerName
+python solo.py PlayerName
 ```
 
 Or profile a whole squad at once (2+ players, you first):
@@ -43,23 +43,32 @@ Or profile a whole squad at once (2+ players, you first):
 python squad.py YourName Teammate1 Teammate2
 ```
 
+Want the full raw stats dump instead of the narrative profile? Use
+`python main.py PlayerName`.
+
 ## How It Works
 
 ```text
-main.py
+solo.py
  ├──▶ Load player name from CLI, cross-reference player-index.json
  ├──▶ Fetch lifetime stats via the PUBG API        → api/player_stats.py
- ├──▶ Render categorized stat tables by mode       → utils/display_stats_by_mode.py
- ├──▶ Display match history, grouped by mode       → utils/display_match_history.py
  ├──▶ Fetch match telemetry for cached matches     → api/telemetry_fetcher.py
- ├──▶ Combat stats: eliminations/deaths breakdown  → utils/combat_stats.py
  ├──▶ Archetype Tag: tempo + range + weapon        → utils/archetype_tag.py
  │     ├─ time-to-first-contact tempo bucket       → utils/tempo_signal.py
  │     ├─ median kill-distance range bucket        → utils/range_signal.py
  │     └─ weapon-class preference / Wildcard       → utils/weapon_signature.py
  ├──▶ Headline Number: confidence-gated "so-what"  → utils/headline_number.py
- ├──▶ Last match brief for this player             → utils/last_match_brief.py
- │     └─ squad-status-at-death cross-reference    → (same module)
+ ├──▶ K/D summary                                  → utils/combat_stats.py
+ ├──▶ Coaching Note: stat reframed as a tip, plus  → utils/solo_coaching.py
+ │     a confidence-gated per-map performance read
+ └──▶ Last match brief for this player             → utils/last_match_brief.py
+       └─ squad-status-at-death cross-reference    → (same module)
+
+main.py (full raw stats view - unchanged, still available)
+ ├──▶ Render categorized stat tables by mode       → utils/display_stats_by_mode.py
+ ├──▶ Display match history, grouped by mode       → utils/display_match_history.py
+ ├──▶ Combat stats: eliminations/deaths breakdown  → utils/combat_stats.py
+ ├──▶ Archetype Tag, Headline Number, Last Match Brief (same modules as solo.py)
  └──▶ Bot detection for the most recent match       → utils/bot_detection.py
 ```
 
@@ -68,17 +77,26 @@ recent matches (see `utils/match_scope.py`) - a widening 30-90 day recency
 window, capped at a configurable match count - using the player's own
 known match IDs from the player-stats API response, never scanning the
 whole shared telemetry cache (which holds every match ever cached across
-every player looked up). `main.py` resolves this scoped match set once
-per run and reuses it across both, rather than each rescanning separately.
+every player looked up). Both `solo.py` and `main.py` resolve this scoped
+match set once per run and reuse it across signals, rather than each
+rescanning separately.
 
-`squad.py` is a separate multi-player entry point (`main.py`'s
-single-player flow is untouched) for profiling a whole squad in one run:
-`utils/squad_read.py` + `utils/squad_roster.py` combine each teammate's
-Archetype Tag into a synergy/coverage read, bolstered with a data-backed
-"who opens first" line when the pattern is consistent enough. Player-stats
-fetches run concurrently across the squad, and telemetry is fetched once
-per unique match across the whole squad rather than once per player, so a
-match two teammates shared only gets pulled once.
+`squad.py` is a separate multi-player entry point for profiling a whole
+squad in one run: `utils/squad_read.py` + `utils/squad_roster.py` combine
+each teammate's Archetype Tag into a synergy/coverage read, bolstered with
+a data-backed "who opens first" line when the pattern is consistent
+enough. Player-stats fetches run concurrently across the squad, and
+telemetry is fetched once per unique match across the whole squad rather
+than once per player, so a match two teammates shared only gets pulled
+once.
+
+`solo.py` is the single-player counterpart - narrative Mode 1 slots for
+one player, no raw stats table or full match history. Squad Read's
+capstone comparison line has no solo equivalent (nothing to compare
+against), so `utils/solo_coaching.py` stands in with a self-coaching line
+(the Headline Number's stat, reframed as a second-person tip) plus a
+confidence-gated per-map performance callout - `main.py`'s raw-stats view
+is untouched and still available for anyone who wants the full dump.
 
 A visual diagram of how every local file relates to the API calls that
 produce it, plus the actual execution order, lives at
@@ -87,7 +105,8 @@ produce it, plus the actual execution order, lives at
 ## Project Structure
 
 ```
-├── main.py                 # CLI entry point (single player)
+├── main.py                 # CLI entry point (single player, full raw stats view)
+├── solo.py                  # CLI entry point (single player, narrative profile)
 ├── squad.py                 # CLI entry point (2+ players at once)
 ├── doctor.py                # Environment health check (Python, deps, .env, API heartbeat)
 ├── setup.ps1                # One-click Windows setup (venv, deps, .env, doctor)

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -50,9 +50,11 @@ order:
 2. **Match-level insight** (current) - mine telemetry for behavioral signal
    instead of just raw stat totals. Mode 1 (pre-game round-start intel) is
    built: Archetype Tag, Weapon Signature, the Headline Number, Last Match
-   Snapshot, Squad Read, and Squad Roster, covering a single player through
-   a full squad. Mode 2 (after-action, opponent/self-improvement framing)
-   and the map drop-zone/flow slot are still ahead.
+   Snapshot, Squad Read, Squad Roster, and a solo profile (`solo.py`) with
+   a self-coaching capstone in place of Squad Read's teammate comparison,
+   covering a single player alone through a full squad. Mode 2
+   (after-action, opponent/self-improvement framing) and the map
+   drop-zone/flow slot are still ahead.
 3. **Automatic squad detection** - recognize when a new round has loaded and
    identify teammates from on-screen player names, without manual input.
 4. **Delivery surface** - move profile output from console text to a web

--- a/solo.py
+++ b/solo.py
@@ -19,6 +19,7 @@ from api.telemetry_fetcher import fetch_telemetry_for_matches
 from utils.archetype_tag import compute_archetype_tag
 from utils.combat_stats import compute_combat_stats
 from utils.headline_number import compute_headline_number
+from utils.killer_intel import compute_killer_intel, format_killer_intel
 from utils.last_match_brief import find_latest_match_for_player, compute_last_match_brief
 from utils.match_scope import select_scoped_match_ids
 from utils.solo_coaching import compute_solo_coaching
@@ -49,9 +50,13 @@ async def _run(playername):
 
     latest_match_id, latest_events = find_latest_match_for_player(player_id, match_ids)
     brief = compute_last_match_brief(player_id, latest_match_id, latest_events) if latest_match_id else None
+    killer_intel_line = None
+    if brief:
+        killer_intel = compute_killer_intel(latest_events, brief["death_info"])
+        killer_intel_line = format_killer_intel(killer_intel)
 
     print("\n\n")
-    render_solo_profile(playername, archetype, headline, combat_stats, coaching, brief)
+    render_solo_profile(playername, archetype, headline, combat_stats, coaching, brief, killer_intel_line)
 
 
 def main():

--- a/solo.py
+++ b/solo.py
@@ -1,0 +1,69 @@
+# ==============================
+# solo CLI entry point - narrative single-player profile
+# ==============================
+"""
+Profile a single player with the same narrative Mode 1 slots as squad.py's
+per-teammate cards (Archetype Tag, Headline Number, Last Match Brief, K/D) -
+no raw stats table, no full match history, no full combat breakdown. Those
+stay available via main.py, which is untouched.
+
+Squad Read's capstone comparison line has no solo equivalent (nothing to
+compare against), so this profile has no capstone line - see issue #40.
+"""
+import argparse
+import asyncio
+
+from api.player_stats import fetch_player_and_match_ids
+from api.rate_limiter import player_api_queue
+from api.telemetry_fetcher import fetch_telemetry_for_matches
+from utils.archetype_tag import compute_archetype_tag
+from utils.combat_stats import compute_combat_stats
+from utils.headline_number import compute_headline_number
+from utils.last_match_brief import find_latest_match_for_player, compute_last_match_brief
+from utils.match_scope import select_scoped_match_ids
+from utils.solo_coaching import compute_solo_coaching
+from utils.display_solo_profile import render_solo_profile
+
+
+async def run(playername):
+    try:
+        await _run(playername)
+    finally:
+        await player_api_queue.close()
+
+
+async def _run(playername):
+    player_id, match_ids = await fetch_player_and_match_ids(playername)
+    print(f"[SUCCESS] Stats saved for '{playername}' (account ID: {player_id})")
+
+    print()
+    print(f"[INFO] Fetching telemetry for {len(match_ids)} matches...")
+    await fetch_telemetry_for_matches(match_ids)
+
+    scoped_match_ids = set(select_scoped_match_ids(match_ids))
+
+    archetype = compute_archetype_tag(player_id, match_ids=scoped_match_ids)
+    headline = compute_headline_number(player_id, match_ids=scoped_match_ids)
+    combat_stats = compute_combat_stats(player_id, match_ids=scoped_match_ids)
+    coaching = compute_solo_coaching(player_id, headline, scoped_match_ids)
+
+    latest_match_id, latest_events = find_latest_match_for_player(player_id, match_ids)
+    brief = compute_last_match_brief(player_id, latest_match_id, latest_events) if latest_match_id else None
+
+    print("\n\n")
+    render_solo_profile(playername, archetype, headline, combat_stats, coaching, brief)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Profile a single player with narrative Mode 1 slots.")
+    parser.add_argument("playername", help="The PUBG player name to profile")
+    args = parser.parse_args()
+
+    try:
+        asyncio.run(run(args.playername))
+    except Exception as e:
+        print(f"[ERROR] {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_killer_intel.py
+++ b/tests/test_killer_intel.py
@@ -1,0 +1,149 @@
+##########
+# Unit Test for Killer Intel (solo.py's replacement for squad status)
+# from root of project: `python -m unittest discover tests`
+##########
+
+import unittest
+
+from utils.killer_intel import compute_killer_intel, format_killer_intel
+
+ME = "account.me"
+KILLER = "account.killer"
+OTHER_VICTIM = "account.other"
+
+
+def match_start(timestamp="2026-01-01T00:00:00.000Z"):
+    return {"_T": "LogMatchStart", "_D": timestamp}
+
+
+def match_end(entries):
+    return {"_T": "LogMatchEnd", "characters": entries}
+
+
+def match_end_entry(account_id, ranking):
+    return {"character": {"accountId": account_id, "ranking": ranking}}
+
+
+def create_event(account_id):
+    return {"_T": "LogPlayerCreate", "character": {"accountId": account_id, "type": "user"}}
+
+
+def damage_event(attacker_id, victim_id, seconds_after_start):
+    return {
+        "_T": "LogPlayerTakeDamage",
+        "attacker": {"accountId": attacker_id, "type": "user"},
+        "victim": {"accountId": victim_id, "type": "user"},
+        "_D": f"2026-01-01T00:{seconds_after_start // 60:02d}:{seconds_after_start % 60:02d}.000Z",
+    }
+
+
+def kill_event(killer_id, victim_id, seconds_after_start, is_suicide=False):
+    return {
+        "_T": "LogPlayerKillV2",
+        "isSuicide": is_suicide,
+        "killer": {"accountId": killer_id, "type": "user"},
+        "victim": {"accountId": victim_id, "type": "user"},
+        "_D": f"2026-01-01T00:{seconds_after_start // 60:02d}:{seconds_after_start % 60:02d}.000Z",
+    }
+
+
+class TestComputeKillerIntel(unittest.TestCase):
+
+    def test_none_when_no_death_info(self):
+        self.assertIsNone(compute_killer_intel([], None))
+
+    def test_none_when_killer_account_id_missing(self):
+        death_info = {"killed_by": "Rival", "weapon": "AUG", "distance_m": 20.0}
+        self.assertIsNone(compute_killer_intel([], death_info))
+
+    def test_counts_killer_kills_excluding_suicide_and_self(self):
+        events = [
+            match_start(),
+            damage_event(KILLER, ME, 10),
+            kill_event(KILLER, OTHER_VICTIM, 20),
+            kill_event(KILLER, ME, 30),
+            {"_T": "LogPlayerKillV2", "isSuicide": True, "killer": {"accountId": KILLER, "type": "user"},
+             "victim": {"accountId": KILLER, "type": "user"}, "_D": "2026-01-01T00:00:40.000Z"},
+        ]
+        death_info = {"killed_by": "Rival", "killer_account_id": KILLER, "weapon": "AUG", "distance_m": 20.0}
+
+        intel = compute_killer_intel(events, death_info)
+
+        self.assertEqual(intel["kill_count"], 2)
+        self.assertEqual(intel["killer_name"], "Rival")
+
+    def test_engagement_pace_early_for_fast_contact(self):
+        events = [match_start(), create_event(KILLER), damage_event(KILLER, ME, 10)]
+        death_info = {"killed_by": "Rival", "killer_account_id": KILLER, "weapon": "AUG", "distance_m": 20.0}
+
+        intel = compute_killer_intel(events, death_info)
+
+        self.assertEqual(intel["engagement_pace"], "early")
+
+    def test_engagement_pace_late_for_slow_contact(self):
+        events = [match_start(), create_event(KILLER), damage_event(KILLER, ME, 600)]
+        death_info = {"killed_by": "Rival", "killer_account_id": KILLER, "weapon": "AUG", "distance_m": 20.0}
+
+        intel = compute_killer_intel(events, death_info)
+
+        self.assertEqual(intel["engagement_pace"], "late")
+
+    def test_engagement_pace_unknown_when_killer_never_seen_elsewhere(self):
+        # No LogPlayerCreate for the killer at all - compute_time_to_first_contact_from_events
+        # can't confirm the killer was even present in the cached event stream.
+        events = [match_start()]
+        death_info = {"killed_by": "Rival", "killer_account_id": KILLER, "weapon": "AUG", "distance_m": 20.0}
+
+        intel = compute_killer_intel(events, death_info)
+
+        self.assertEqual(intel["engagement_pace"], "unknown")
+
+    def test_final_rank_from_match_end(self):
+        events = [
+            match_start(),
+            damage_event(KILLER, ME, 10),
+            match_end([match_end_entry(KILLER, 3)]),
+        ]
+        death_info = {"killed_by": "Rival", "killer_account_id": KILLER, "weapon": "AUG", "distance_m": 20.0}
+
+        intel = compute_killer_intel(events, death_info)
+
+        self.assertEqual(intel["final_rank"], 3)
+
+    def test_final_rank_none_when_killer_not_in_match_end(self):
+        events = [match_start(), damage_event(KILLER, ME, 10), match_end([match_end_entry(ME, 5)])]
+        death_info = {"killed_by": "Rival", "killer_account_id": KILLER, "weapon": "AUG", "distance_m": 20.0}
+
+        intel = compute_killer_intel(events, death_info)
+
+        self.assertIsNone(intel["final_rank"])
+
+
+class TestFormatKillerIntel(unittest.TestCase):
+
+    def test_none_passthrough(self):
+        self.assertIsNone(format_killer_intel(None))
+
+    def test_zero_kills_phrased_without_kill_count(self):
+        result = format_killer_intel({
+            "killer_name": "Rival", "kill_count": 0, "engagement_pace": "late", "final_rank": None,
+        })
+        self.assertIn("no other confirmed kills", result)
+
+    def test_singular_kill_phrasing(self):
+        result = format_killer_intel({
+            "killer_name": "Rival", "kill_count": 1, "engagement_pace": "early", "final_rank": None,
+        })
+        self.assertIn("1 kill this match", result)
+        self.assertNotIn("1 kills", result)
+
+    def test_plural_kill_phrasing_and_rank(self):
+        result = format_killer_intel({
+            "killer_name": "Rival", "kill_count": 4, "engagement_pace": "mid", "final_rank": 2,
+        })
+        self.assertIn("4 kills this match", result)
+        self.assertIn("finish #2", result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_last_match_brief.py
+++ b/tests/test_last_match_brief.py
@@ -64,7 +64,10 @@ class TestComputeLastMatchBrief(unittest.TestCase):
         self.assertEqual(brief["time_alive_seconds"], 300)
         self.assertEqual(brief["kill_count"], 0)
         self.assertIsNone(brief["most_used_weapon"])
-        self.assertEqual(brief["death_info"], {"killed_by": "Rival", "weapon": "AUG", "distance_m": 20.9})
+        self.assertEqual(
+            brief["death_info"],
+            {"killed_by": "Rival", "killer_account_id": KILLER, "weapon": "AUG", "distance_m": 20.9},
+        )
 
     def test_survivor_has_no_death_info_and_uses_match_end_time(self):
         events = [

--- a/tests/test_solo_coaching.py
+++ b/tests/test_solo_coaching.py
@@ -1,0 +1,151 @@
+##########
+# Unit Test for Solo Coaching Note (Squad Read's capstone stand-in for solo.py)
+# from root of project: `python -m unittest discover tests`
+##########
+
+import json
+import os
+import tempfile
+import unittest
+
+from utils.solo_coaching import (
+    compute_coaching_line,
+    compute_map_line,
+    MIN_MATCHES_FOR_MAP_SIGNAL,
+)
+
+ME = "account.me"
+RIVAL = "account.rival"
+
+
+def match_start(day, map_name="Baltic_Main"):
+    return {"_T": "LogMatchStart", "_D": f"2026-07-{day:02d}T00:00:00.000Z", "mapName": map_name}
+
+
+def create_event(account_id):
+    return {"_T": "LogPlayerCreate", "character": {"accountId": account_id, "type": "user"}}
+
+
+def damage_event(attacker_id, victim_id, damage):
+    return {
+        "_T": "LogPlayerTakeDamage",
+        "attacker": {"accountId": attacker_id, "type": "user"},
+        "victim": {"accountId": victim_id, "type": "user"},
+        "damage": damage,
+    }
+
+
+class TestComputeCoachingLine(unittest.TestCase):
+
+    def test_known_stat_keys_return_fixed_coaching_text(self):
+        for stat_key in ("kills_before_death", "revives", "damage"):
+            with self.subTest(stat_key=stat_key):
+                result = compute_coaching_line({"stat_key": stat_key, "value": 5})
+                self.assertIsNotNone(result)
+
+    def test_close_range_win_rate_direction_changes_tone(self):
+        winning = compute_coaching_line({"stat_key": "close_range_win_rate", "value": 0.8})
+        losing = compute_coaching_line({"stat_key": "close_range_win_rate", "value": 0.2})
+        self.assertIn("trust your instinct", winning)
+        self.assertIn("disengaging earlier", losing)
+
+    def test_knockdown_conversion_direction_changes_tone(self):
+        converting = compute_coaching_line({"stat_key": "knockdown_conversion_rate", "value": 0.9})
+        not_converting = compute_coaching_line({"stat_key": "knockdown_conversion_rate", "value": 0.1})
+        self.assertIn("finish what you start", converting)
+        self.assertIn("follow up faster", not_converting)
+
+    def test_fallback_kill_count_has_no_coaching_line(self):
+        result = compute_coaching_line({"stat_key": "fallback_kill_count", "value": None})
+        self.assertIsNone(result)
+
+
+class TestComputeMapLine(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+        self.match_ids = []
+
+    def _write_match(self, day, map_name, damage):
+        events = [match_start(day, map_name), create_event(ME), damage_event(ME, RIVAL, damage)]
+        match_id = f"match-{day}"
+        path = os.path.join(self.tmpdir.name, f"{match_id}-telemetry.json")
+        with open(path, "w") as f:
+            json.dump(events, f)
+        self.match_ids.append(match_id)
+
+    def test_none_below_overall_minimum(self):
+        for day in range(1, MIN_MATCHES_FOR_MAP_SIGNAL - 1):
+            self._write_match(day, "Baltic_Main", damage=300)
+
+        result = compute_map_line(ME, self.match_ids, telemetry_dir=self.tmpdir.name)
+
+        self.assertIsNone(result)
+
+    def test_none_when_no_single_map_clears_the_match_count_bar(self):
+        # 12 matches total, but spread thin across maps - no single map has
+        # MIN_MATCHES_FOR_MAP_SIGNAL matches of its own.
+        maps = ["Baltic_Main", "Desert_Main", "Savage_Main"]
+        for day in range(1, 13):
+            self._write_match(day, maps[day % 3], damage=300)
+
+        result = compute_map_line(ME, self.match_ids, telemetry_dir=self.tmpdir.name)
+
+        self.assertIsNone(result)
+
+    def test_none_when_deviation_too_small(self):
+        for day in range(1, 9):
+            self._write_match(day, "Baltic_Main", damage=300)
+        for day in range(9, 17):
+            self._write_match(day, "Desert_Main", damage=310)  # ~3% deviation, below threshold
+
+        result = compute_map_line(ME, self.match_ids, telemetry_dir=self.tmpdir.name)
+
+        self.assertIsNone(result)
+
+    def test_surfaces_map_with_notably_higher_damage(self):
+        # A third, small (< match-count bar) map bucket shifts the overall
+        # mean so Baltic sits close to it (deviation stays under threshold)
+        # while Desert clears it - avoids two equal-sized buckets landing
+        # symmetrically either side of the mean, which would tie on |deviation|.
+        for day in range(1, 9):
+            self._write_match(day, "Baltic_Main", damage=500)
+        for day in range(9, 17):
+            self._write_match(day, "Desert_Main", damage=600)
+        for day in range(17, 20):
+            self._write_match(day, "Savage_Main", damage=100)
+
+        result = compute_map_line(ME, self.match_ids, telemetry_dir=self.tmpdir.name)
+
+        self.assertIn("Miramar", result)
+        self.assertIn("above", result)
+
+    def test_surfaces_map_with_notably_lower_damage(self):
+        for day in range(1, 9):
+            self._write_match(day, "Baltic_Main", damage=500)
+        for day in range(9, 17):
+            self._write_match(day, "Desert_Main", damage=200)
+        for day in range(17, 20):
+            self._write_match(day, "Savage_Main", damage=900)
+
+        result = compute_map_line(ME, self.match_ids, telemetry_dir=self.tmpdir.name)
+
+        self.assertIn("Miramar", result)
+        self.assertIn("below", result)
+
+    def test_unmapped_internal_name_falls_back_to_raw_string(self):
+        for day in range(1, 9):
+            self._write_match(day, "Baltic_Main", damage=500)
+        for day in range(9, 17):
+            self._write_match(day, "Unreleased_Test_Map", damage=600)
+        for day in range(17, 20):
+            self._write_match(day, "Savage_Main", damage=100)
+
+        result = compute_map_line(ME, self.match_ids, telemetry_dir=self.tmpdir.name)
+
+        self.assertIn("Unreleased_Test_Map", result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/utils/display_last_match_brief.py
+++ b/utils/display_last_match_brief.py
@@ -3,7 +3,7 @@
 # ==============================
 
 
-def render_last_match_brief(playername, brief, played_with_you=None):
+def render_last_match_brief(playername, brief, played_with_you=None, show_squad_status=True, killer_intel_line=None):
     print("=============================")
     print(f"📋 Last Match Brief - {playername}")
     print("=============================")
@@ -26,8 +26,11 @@ def render_last_match_brief(playername, brief, played_with_you=None):
     else:
         print("Died To    : Survived to match end")
 
+    if killer_intel_line:
+        print(f"Who Killed You: {killer_intel_line}")
+
     squad_status = brief.get("squad_status")
-    if squad_status:
+    if show_squad_status and squad_status:
         print("Squad Status at the time:")
         for teammate in squad_status:
             if teammate["status"] == "alive":

--- a/utils/display_solo_profile.py
+++ b/utils/display_solo_profile.py
@@ -7,7 +7,7 @@ from utils.display_headline_number import render_headline_number
 from utils.display_last_match_brief import render_last_match_brief
 
 
-def render_solo_profile(playername, archetype, headline, combat_stats, coaching, brief):
+def render_solo_profile(playername, archetype, headline, combat_stats, coaching, brief, killer_intel_line=None):
     print("=============================================")
     print(f"🧍 SOLO PROFILE - {playername}")
     print("=============================================")
@@ -28,4 +28,4 @@ def render_solo_profile(playername, archetype, headline, combat_stats, coaching,
 
     if brief:
         print()
-        render_last_match_brief(playername, brief)
+        render_last_match_brief(playername, brief, show_squad_status=False, killer_intel_line=killer_intel_line)

--- a/utils/display_solo_profile.py
+++ b/utils/display_solo_profile.py
@@ -1,0 +1,31 @@
+# ==============================
+# utils/display_solo_profile.py
+# ==============================
+from utils.display_archetype_tag import render_archetype_tag
+from utils.display_combat_stats import render_kd_summary
+from utils.display_headline_number import render_headline_number
+from utils.display_last_match_brief import render_last_match_brief
+
+
+def render_solo_profile(playername, archetype, headline, combat_stats, coaching, brief):
+    print("=============================================")
+    print(f"🧍 SOLO PROFILE - {playername}")
+    print("=============================================")
+
+    render_archetype_tag(archetype)
+    render_headline_number(headline)
+    render_kd_summary(combat_stats)
+
+    if coaching["coaching_line"] or coaching["map_line"]:
+        print()
+        print("=============================")
+        print("🎯 Coaching Note")
+        print("=============================")
+        if coaching["coaching_line"]:
+            print(coaching["coaching_line"])
+        if coaching["map_line"]:
+            print(coaching["map_line"])
+
+    if brief:
+        print()
+        render_last_match_brief(playername, brief)

--- a/utils/headline_number.py
+++ b/utils/headline_number.py
@@ -254,6 +254,7 @@ def compute_headline_number(account_id, match_ids=None, telemetry_dir=TELEMETRY_
             candidates.append({
                 "key": "kills_before_death",
                 "score": _score_magnitude(values),
+                "value": statistics.mean(values),
                 "sentence": (
                     f"Averages {statistics.mean(values):.1f} kills before first death "
                     f"over {possessive} last {matches_analyzed} matches"
@@ -265,6 +266,7 @@ def compute_headline_number(account_id, match_ids=None, telemetry_dir=TELEMETRY_
             candidates.append({
                 "key": "revives",
                 "score": _score_magnitude(values),
+                "value": statistics.mean(values),
                 "sentence": (
                     f"Averages {statistics.mean(values):.1f} revives per match over {possessive} "
                     f"last {matches_analyzed} matches"
@@ -276,6 +278,7 @@ def compute_headline_number(account_id, match_ids=None, telemetry_dir=TELEMETRY_
             candidates.append({
                 "key": "damage",
                 "score": _score_magnitude(values),
+                "value": statistics.mean(values),
                 "sentence": (
                     f"Averages {statistics.mean(values):.0f} damage per match over {possessive} "
                     f"last {matches_analyzed} matches"
@@ -289,6 +292,7 @@ def compute_headline_number(account_id, match_ids=None, telemetry_dir=TELEMETRY_
             candidates.append({
                 "key": "close_range_win_rate",
                 "score": _score_rate(values),
+                "value": statistics.mean(values),
                 "sentence": (
                     f"Wins {statistics.mean(values):.0%} of close-range fights "
                     f"(inside {CLOSE_RANGE_MAX_METERS}m) - {wins}/{len(values)} across "
@@ -303,6 +307,7 @@ def compute_headline_number(account_id, match_ids=None, telemetry_dir=TELEMETRY_
             candidates.append({
                 "key": "knockdown_conversion_rate",
                 "score": _score_rate(values),
+                "value": statistics.mean(values),
                 "sentence": (
                     f"Converts {statistics.mean(values):.0%} of knockdowns into kills - "
                     f"{converted}/{len(values)} over {possessive} last {matches_with_knockdowns} matches"
@@ -315,6 +320,7 @@ def compute_headline_number(account_id, match_ids=None, telemetry_dir=TELEMETRY_
             "headline": best["sentence"],
             "stat_key": best["key"],
             "score": best["score"],
+            "value": best["value"],
             "matches_analyzed": matches_analyzed,
         }
 
@@ -323,5 +329,6 @@ def compute_headline_number(account_id, match_ids=None, telemetry_dir=TELEMETRY_
         if matches_analyzed else "Not enough data yet",
         "stat_key": "fallback_kill_count",
         "score": None,
+        "value": None,
         "matches_analyzed": matches_analyzed,
     }

--- a/utils/killer_intel.py
+++ b/utils/killer_intel.py
@@ -1,0 +1,90 @@
+# ==============================
+# utils/killer_intel.py
+# ==============================
+"""
+Killer Intel: solo.py's replacement for Last Match Brief's "Squad Status at
+the time" section, which has no meaning without a squad - if you died, the
+more useful read is how the player who killed you actually played that
+match, not who else was on your own team.
+
+Scoped to the single match you died in - reuses tempo_signal.py's existing
+per-match first-contact reading (already exactly the "aggressive from the
+start vs. held back" signal) against the killer's own account within that
+match's events, rather than parsing anything new.
+"""
+from utils.tempo_signal import compute_time_to_first_contact_from_events, \
+    VERY_FAST_CONTACT_SECONDS, MODERATE_DELAY_SECONDS
+
+PACE_PHRASES = {
+    "early": "came out swinging early, engaging well before you crossed paths",
+    "mid": "played a measured mid-game, engaging once gear was sorted",
+    "late": "held back and stayed quiet for most of the round",
+    "unknown": "had no other engagements logged this match",
+}
+
+
+def _engagement_pace(contact_seconds):
+    if contact_seconds is None:
+        return "unknown"
+    if contact_seconds <= VERY_FAST_CONTACT_SECONDS:
+        return "early"
+    if contact_seconds <= MODERATE_DELAY_SECONDS:
+        return "mid"
+    return "late"
+
+
+def compute_killer_intel(events, death_info):
+    """Kill count, engagement pace, and final placement for whoever killed
+    you in this match - or None if you survived to match end (no killer)
+    or the killing event's account ID wasn't captured."""
+    if not death_info or not death_info.get("killer_account_id"):
+        return None
+    killer_id = death_info["killer_account_id"]
+
+    kill_count = 0
+    for event in events:
+        if event.get("_T") != "LogPlayerKillV2" or event.get("isSuicide"):
+            continue
+        killer = event.get("killer") or {}
+        victim = event.get("victim") or {}
+        if killer.get("accountId") == killer_id and killer.get("type") == "user" \
+                and victim.get("type") == "user" and victim.get("accountId") != killer_id:
+            kill_count += 1
+
+    contact = compute_time_to_first_contact_from_events(killer_id, events)
+    contact_seconds = contact["contact_seconds"] if contact else None
+
+    match_end = next((e for e in events if e.get("_T") == "LogMatchEnd"), None)
+    final_rank = None
+    if match_end:
+        entry = next(
+            (c for c in match_end.get("characters", []) if (c.get("character") or {}).get("accountId") == killer_id),
+            None,
+        )
+        if entry:
+            final_rank = entry["character"].get("ranking")
+
+    return {
+        "killer_name": death_info["killed_by"],
+        "kill_count": kill_count,
+        "engagement_pace": _engagement_pace(contact_seconds),
+        "final_rank": final_rank,
+    }
+
+
+def format_killer_intel(intel):
+    if intel is None:
+        return None
+
+    pace_phrase = PACE_PHRASES[intel["engagement_pace"]]
+    kill_count = intel["kill_count"]
+    if kill_count == 0:
+        kill_phrase = "with no other confirmed kills this match"
+    elif kill_count == 1:
+        kill_phrase = "picking up 1 kill this match"
+    else:
+        kill_phrase = f"racking up {kill_count} kills this match"
+
+    rank_phrase = f", and went on to finish #{intel['final_rank']}" if intel["final_rank"] else ""
+
+    return f"{intel['killer_name']} {pace_phrase}, {kill_phrase}{rank_phrase}."

--- a/utils/last_match_brief.py
+++ b/utils/last_match_brief.py
@@ -202,6 +202,7 @@ def compute_last_match_brief(account_id, match_id, events):
             kdi = event.get("killerDamageInfo") or {}
             death_info = {
                 "killed_by": killer.get("name", "Unknown"),
+                "killer_account_id": killer.get("accountId"),
                 "weapon": _clean_weapon_name(kdi.get("damageCauserName")),
                 "distance_m": round(kdi.get("distance", 0) / 100, 1),
             }

--- a/utils/solo_coaching.py
+++ b/utils/solo_coaching.py
@@ -1,0 +1,185 @@
+# ==============================
+# utils/solo_coaching.py
+# ==============================
+"""
+Solo Coaching Note: solo.py's stand-in for Squad Read's capstone line, which
+has no meaning without a teammate to compare against (see issue #40). Same
+two-line shape as Squad Read - a general read (here: the Headline Number's
+already-chosen stat, reframed as second-person coaching) plus a data-backed
+bolstered line (here: a per-map performance callout), only shown when it
+clears the same MIN_MATCHES_FOR_SIGNAL=8 confidence bar used everywhere else
+in this tool.
+
+Map-based coaching was validated against real cached data before building:
+mapName is reliably present in telemetry, and per-map performance does vary
+meaningfully for a real player - but most players won't have 8+ cached
+matches on any single map, so the map line is expected to often not appear.
+That's the same confidence-gating philosophy as the rest of the project, not
+a bug.
+"""
+import glob
+import json
+import os
+import statistics
+
+from utils.headline_number import MIN_MATCHES_FOR_CANDIDATE
+from utils.last_match_brief import player_present_in_match
+
+TELEMETRY_DIR = "match-telemetry"
+
+# Same MIN_*_FOR_SIGNAL=8 convention used across tempo/range/weapon/headline.
+MIN_MATCHES_FOR_MAP_SIGNAL = MIN_MATCHES_FOR_CANDIDATE
+
+# How far a map's average damage has to deviate from the player's own
+# overall average before it's worth calling out - guards against noise in
+# a map bucket that's technically over the match-count bar but still close
+# to the player's normal performance.
+MAP_DEVIATION_THRESHOLD = 0.20
+
+MAP_DISPLAY_NAMES = {
+    "Baltic_Main": "Erangel",
+    "Desert_Main": "Miramar",
+    "Savage_Main": "Sanhok",
+    "DihorOtok_Main": "Vikendi",
+    "Summerland_Main": "Karakin",
+    "Tiger_Main": "Taego",
+    "Kiki_Main": "Deston",
+    "Neon_Main": "Rondo",
+    "Chimera_Main": "Paramo",
+    "Heaven_Main": "Haven",
+    "Range_Main": "Camp Jackal",
+}
+
+COACHING_BY_STAT_KEY = {
+    "kills_before_death": (
+        "You keep the pressure on once a fight starts - lean into staying "
+        "aggressive after your first kill instead of playing it safe."
+    ),
+    "revives": (
+        "You're a support anchor - keep prioritizing revives and squad "
+        "positioning over solo pushes."
+    ),
+    "damage": (
+        "You put out consistent damage match to match - work on converting "
+        "more of that damage into confirmed kills."
+    ),
+}
+
+
+def _load_telemetry_files(match_ids=None, telemetry_dir=TELEMETRY_DIR):
+    for path in glob.glob(os.path.join(telemetry_dir, "*-telemetry.json")):
+        match_id = os.path.basename(path).replace("-telemetry.json", "")
+        if match_ids is not None and match_id not in match_ids:
+            continue
+        with open(path, "r") as f:
+            yield json.load(f)
+
+
+def _map_display_name(map_name):
+    return MAP_DISPLAY_NAMES.get(map_name, map_name)
+
+
+def compute_coaching_line(headline):
+    """Reframe the Headline Number's already-chosen stat as a second-person
+    coaching note - no new computation, just a different lens on data
+    already trusted enough to headline."""
+    stat_key = headline.get("stat_key")
+    value = headline.get("value")
+
+    if stat_key in COACHING_BY_STAT_KEY:
+        return COACHING_BY_STAT_KEY[stat_key]
+
+    if stat_key == "close_range_win_rate" and value is not None:
+        if value >= 0.5:
+            return (
+                "You win close-range fights more often than not - trust "
+                "your instinct to push in close."
+            )
+        return (
+            "Close-range fights are costing you - consider disengaging "
+            "earlier or repositioning before committing to one."
+        )
+
+    if stat_key == "knockdown_conversion_rate" and value is not None:
+        if value >= 0.5:
+            return (
+                "You finish what you start - once someone's knocked down, "
+                "trust yourself to close it out."
+            )
+        return (
+            "You knock people down but don't always finish - follow up "
+            "faster to secure the kill before they get revived."
+        )
+
+    return None
+
+
+def compute_map_line(account_id, match_ids, telemetry_dir=TELEMETRY_DIR):
+    """Bolstered per-map damage callout - the single most extreme map that
+    clears both the match-count bar and the deviation threshold, or None if
+    nothing qualifies."""
+    damage_by_map = {}
+    overall_damage = []
+
+    for events in _load_telemetry_files(match_ids, telemetry_dir):
+        if not player_present_in_match(account_id, events):
+            continue
+        start_event = next((e for e in events if e.get("_T") == "LogMatchStart"), None)
+        if not start_event:
+            continue
+        map_name = start_event.get("mapName")
+        if not map_name:
+            continue
+
+        damage = 0
+        for event in events:
+            if event.get("_T") != "LogPlayerTakeDamage":
+                continue
+            attacker = event.get("attacker") or {}
+            victim = event.get("victim") or {}
+            if attacker.get("accountId") == account_id and attacker.get("type") == "user" \
+                    and victim.get("type") == "user" and victim.get("accountId") != account_id:
+                damage += event.get("damage", 0)
+
+        damage_by_map.setdefault(map_name, []).append(damage)
+        overall_damage.append(damage)
+
+    if len(overall_damage) < MIN_MATCHES_FOR_CANDIDATE:
+        return None
+
+    overall_mean = statistics.mean(overall_damage)
+    if overall_mean == 0:
+        return None
+
+    candidates = []
+    for map_name, values in damage_by_map.items():
+        if len(values) < MIN_MATCHES_FOR_MAP_SIGNAL:
+            continue
+        map_mean = statistics.mean(values)
+        deviation = (map_mean - overall_mean) / overall_mean
+        if abs(deviation) >= MAP_DEVIATION_THRESHOLD:
+            candidates.append((abs(deviation), deviation, map_name, map_mean, len(values)))
+
+    if not candidates:
+        return None
+
+    candidates.sort(key=lambda c: c[0], reverse=True)
+    _, deviation, map_name, map_mean, matches_on_map = candidates[0]
+    label = _map_display_name(map_name)
+
+    if deviation > 0:
+        return (
+            f"You average {map_mean:.0f} damage per match on {label}, well above your "
+            f"{overall_mean:.0f} overall average ({matches_on_map} matches there) - lean into drops there."
+        )
+    return (
+        f"You average {map_mean:.0f} damage per match on {label}, below your "
+        f"{overall_mean:.0f} overall average ({matches_on_map} matches there) - worth extra caution there."
+    )
+
+
+def compute_solo_coaching(account_id, headline, match_ids, telemetry_dir=TELEMETRY_DIR):
+    return {
+        "coaching_line": compute_coaching_line(headline),
+        "map_line": compute_map_line(account_id, match_ids, telemetry_dir=telemetry_dir),
+    }


### PR DESCRIPTION
## Summary
- New `solo.py` entry point: narrative Mode 1 slots (Archetype Tag, Headline Number, K/D, Coaching Note, Last Match Brief) for a single player, no raw stats table or full match history. `main.py` is untouched and still available for the full detailed view.
- Coaching Note stands in for Squad Read's capstone (no teammate to compare against): a self-coaching line reframing the Headline Number's stat, plus a confidence-gated per-map performance callout (validated against real cached telemetry - gated at 8+ matches per map and >=20% deviation from the player's own average).
- Last Match Brief's squad status section (meaningless for a solo profile) is replaced with killer intel: the killer's kill count, engagement pace (early/mid/late first contact, reused from tempo_signal.py), and final placement. main.py's squad status still renders by default (opt-out param, non-breaking).

## Test plan
- [x] `python -m unittest discover tests` passes (148 tests)
- [x] `python doctor.py` passes
- [x] Validated live against real cached players (`solo.py ashleykan`, `solo.py hwinn`) across both coaching-line branches (magnitude stat and rate stat)

Closes #40