### PR TITLE
Scope Range and Weapon signals to team-mode matches only

### DIFF
--- a/api/player_stats.py
+++ b/api/player_stats.py
@@ -16,6 +16,11 @@ HEADERS = {
 }
 BASE_URL = "https://api.pubg.com/shards/steam"
 
+# Which relationship keys represent team-mode (duo/squad) matches, as
+# opposed to solo-queue (matchesSolo/matchesSoloFPP). Used to scope the
+# Range and Weapon signals to team-mode play only - see issue #42.
+TEAM_MODE_RELATIONSHIP_KEYS = {"matchesDuo", "matchesDuoFPP", "matchesSquad", "matchesSquadFPP"}
+
 
 async def fetch_player_stats(playername):
     # Get account ID from player name
@@ -37,13 +42,21 @@ async def fetch_player_and_match_ids(playername):
     return their known match ID list - the shared first step needed by
     both the single-player CLI (main.py) and multi-player squad lookups
     (squad.py), so both stay behaviorally identical for this step.
+
+    Also returns the team-mode-only subset (duo/squad, excluding solo
+    queue) - see TEAM_MODE_RELATIONSHIP_KEYS - for callers scoping
+    Range/Weapon signals to team-mode play.
     """
     data, player_id = await fetch_player_stats(playername)
     save_json(data, f"playerstats/{playername}.json")
 
     match_ids = []
+    team_mode_match_ids = []
     for key, relationship in data["data"]["relationships"].items():
         if key.startswith("matches"):
-            match_ids.extend([entry["id"] for entry in relationship.get("data", [])])
+            ids = [entry["id"] for entry in relationship.get("data", [])]
+            match_ids.extend(ids)
+            if key in TEAM_MODE_RELATIONSHIP_KEYS:
+                team_mode_match_ids.extend(ids)
 
-    return player_id, match_ids
+    return player_id, match_ids, team_mode_match_ids

--- a/main.py
+++ b/main.py
@@ -30,7 +30,7 @@ async def run(playername):
         await player_api_queue.close()
 
 async def _run(playername):
-    player_id, match_ids = await fetch_player_and_match_ids(playername)
+    player_id, match_ids, team_mode_match_ids = await fetch_player_and_match_ids(playername)
     print(f"[SUCCESS] Stats saved for '{playername}' (account ID: {player_id})")
     print()
     print()
@@ -59,10 +59,11 @@ async def _run(playername):
     # matches, from the player-stats API response above) is the candidate
     # list - never the whole shared cache, which holds other players' too.
     scoped_match_ids = set(select_scoped_match_ids(match_ids))
+    team_mode_scoped_ids = set(select_scoped_match_ids(team_mode_match_ids))
 
     # Display Archetype Tag (tempo + range + weapon signature) mined from cached telemetry
     print("\n\n")
-    archetype = compute_archetype_tag(player_id, match_ids=scoped_match_ids)
+    archetype = compute_archetype_tag(player_id, match_ids=scoped_match_ids, team_mode_match_ids=team_mode_scoped_ids)
     render_archetype_tag(archetype)
 
     # Display the Headline Number: one differentiating, confidence-gated stat

--- a/solo.py
+++ b/solo.py
@@ -34,7 +34,7 @@ async def run(playername):
 
 
 async def _run(playername):
-    player_id, match_ids = await fetch_player_and_match_ids(playername)
+    player_id, match_ids, team_mode_match_ids = await fetch_player_and_match_ids(playername)
     print(f"[SUCCESS] Stats saved for '{playername}' (account ID: {player_id})")
 
     print()
@@ -42,8 +42,9 @@ async def _run(playername):
     await fetch_telemetry_for_matches(match_ids)
 
     scoped_match_ids = set(select_scoped_match_ids(match_ids))
+    team_mode_scoped_ids = set(select_scoped_match_ids(team_mode_match_ids))
 
-    archetype = compute_archetype_tag(player_id, match_ids=scoped_match_ids)
+    archetype = compute_archetype_tag(player_id, match_ids=scoped_match_ids, team_mode_match_ids=team_mode_scoped_ids)
     headline = compute_headline_number(player_id, match_ids=scoped_match_ids)
     combat_stats = compute_combat_stats(player_id, match_ids=scoped_match_ids)
     coaching = compute_solo_coaching(player_id, headline, scoped_match_ids)

--- a/squad.py
+++ b/squad.py
@@ -40,9 +40,14 @@ async def _run(playernames):
     fetched = await asyncio.gather(*(fetch_player_and_match_ids(name) for name in playernames))
 
     members = []
-    for name, (account_id, match_ids) in zip(playernames, fetched):
+    for name, (account_id, match_ids, team_mode_match_ids) in zip(playernames, fetched):
         print(f"[SUCCESS] Stats saved for '{name}' (account ID: {account_id})")
-        members.append({"name": name, "account_id": account_id, "match_ids": match_ids})
+        members.append({
+            "name": name,
+            "account_id": account_id,
+            "match_ids": match_ids,
+            "team_mode_match_ids": team_mode_match_ids,
+        })
 
     # One combined, deduplicated telemetry fetch for the whole squad - a
     # match two teammates played together only needs pulling once
@@ -61,8 +66,9 @@ async def _run(playernames):
     combat_stats = {}
     for i, m in enumerate(members):
         scoped = set(select_scoped_match_ids(m["match_ids"]))
+        team_mode_scoped = set(select_scoped_match_ids(m["team_mode_match_ids"]))
         possessive = "your" if i == 0 else "their"
-        archetype = compute_archetype_tag(m["account_id"], match_ids=scoped)
+        archetype = compute_archetype_tag(m["account_id"], match_ids=scoped, team_mode_match_ids=team_mode_scoped)
         m["archetype"] = archetype
         archetypes[m["name"]] = archetype
         headlines[m["name"]] = compute_headline_number(m["account_id"], match_ids=scoped, possessive=possessive)

--- a/tests/test_archetype_tag.py
+++ b/tests/test_archetype_tag.py
@@ -94,6 +94,40 @@ class TestComputeArchetypeTag(unittest.TestCase):
         self.assertEqual(result["tempo"]["tempo_tag"], "Slow-Roll Patient")
         self.assertIn("Passive", result["short_tag"])
 
+    def test_team_mode_match_ids_scopes_range_and_weapon_but_not_tempo(self):
+        # 8 team-mode matches: fast Close-Range AR kills.
+        for i in range(8):
+            self._write_match(f"team-{i}", [
+                match_start(),
+                create_event(ME),
+                damage_event(ME, RIVAL, 20),
+                kill_event(ME, RIVAL, "WeapAK47_C", 15, 25),
+            ])
+        # 8 additional solo-mode matches: also fast (same tempo), but
+        # Long-Range SR kills - would flip Range/Weapon if not excluded.
+        for i in range(8):
+            self._write_match(f"solo-{i}", [
+                match_start(),
+                create_event(ME),
+                damage_event(ME, RIVAL, 20),
+                kill_event(ME, RIVAL, "WeapKar98k_C", 200, 25),
+            ])
+
+        all_ids = [f"team-{i}" for i in range(8)] + [f"solo-{i}" for i in range(8)]
+        team_ids = [f"team-{i}" for i in range(8)]
+
+        result = compute_archetype_tag(
+            ME, telemetry_dir=self.tmpdir.name, match_ids=all_ids, team_mode_match_ids=team_ids,
+        )
+
+        # Tempo stays on the full (unscoped) match set - 16 fast matches either way.
+        self.assertEqual(result["tempo"]["tempo_tag"], "Hot-Drop Headhunter")
+        self.assertEqual(result["tempo"]["matches_analyzed"], 16)
+        # Range/Weapon reflect only the 8 team-mode matches, not all 16.
+        self.assertEqual(result["range"]["range_bucket"], "Close-Range")
+        self.assertEqual(result["weapon"]["signature"], "AR")
+        self.assertEqual(result["range"]["kills_analyzed"], 8)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/utils/archetype_tag.py
+++ b/utils/archetype_tag.py
@@ -20,18 +20,26 @@ TEMPO_TO_TEMPERAMENT = {
 }
 
 
-def compute_archetype_tag(account_id, match_ids, telemetry_dir=TELEMETRY_DIR):
+def compute_archetype_tag(account_id, match_ids, telemetry_dir=TELEMETRY_DIR, team_mode_match_ids=None):
     """Combine tempo, range, and weapon-signature into the Archetype Tag.
 
     match_ids is the player's scoped match set (see match_scope.py),
     resolved once by the caller and reused across all three signals here
     rather than each one independently rescanning the telemetry cache.
+
+    team_mode_match_ids, if given, scopes Range and Weapon specifically to
+    team-mode (duo/squad) matches - validated against real data (issue
+    #42): engagement range runs consistently shorter in team modes than
+    solo, enough to flip the bucket for some players, while Tempo showed
+    no mode sensitivity and stays on the full match_ids scope. Defaults to
+    match_ids when not given, so existing callers are unaffected.
     """
     match_ids = set(match_ids)
+    range_weapon_match_ids = set(team_mode_match_ids) if team_mode_match_ids is not None else match_ids
 
     tempo = compute_tempo_signal(account_id, match_ids=match_ids, telemetry_dir=telemetry_dir)
-    range_signal = compute_range_signal(account_id, match_ids=match_ids, telemetry_dir=telemetry_dir)
-    weapon = compute_weapon_signature(account_id, match_ids=match_ids, telemetry_dir=telemetry_dir)
+    range_signal = compute_range_signal(account_id, match_ids=range_weapon_match_ids, telemetry_dir=telemetry_dir)
+    weapon = compute_weapon_signature(account_id, match_ids=range_weapon_match_ids, telemetry_dir=telemetry_dir)
 
     temperament = TEMPO_TO_TEMPERAMENT.get(tempo["tempo_tag"])
     range_bucket = range_signal["range_bucket"]


### PR DESCRIPTION
## Summary
- Archetype Tag's Range and Weapon signals now scope to team-mode (duo/squad) matches only, excluding solo queue. Tempo, Headline Number, combat stats, telemetry-fetch caps, and Last Match Brief are untouched.
- Validated against real cached data across three players before implementing: Tempo showed no mode sensitivity, but Range consistently ran shorter in team modes than solo, enough to flip the bucket for one of three players tested (Long-Range at 34.4m solo -> Mid-Range at 25.6m team).
- `fetch_player_and_match_ids` now returns a third value (team-mode-only match IDs); `compute_archetype_tag` takes an optional `team_mode_match_ids` param, defaulting to the full match set for backward compatibility.

## Test plan
- [x] `python -m unittest discover tests` passes (149 tests)
- [x] `python doctor.py` passes
- [x] Validated live: `solo.py Shaply` (real mode-sensitive player - Range/Weapon now correctly team-mode-scoped), `squad.py ashleykan hwinn shane_doe` (zero-solo-match trio, confirms no-op/backward-safe when a player has no solo history), `main.py Shaply` (full smoke test per this repo's convention)

Closes #42